### PR TITLE
Add alias-able module loader class

### DIFF
--- a/packages/internals/loader/README.md
+++ b/packages/internals/loader/README.md
@@ -1,0 +1,15 @@
+# Fractal loader
+
+Alias-able JS module loader built on top of Webpack's `enhanced-resolve` package.
+
+[![NPM Version](https://img.shields.io/npm/v/@frctl/loader.svg?style=flat-square)](https://www.npmjs.com/package/@frctl/loader)
+
+## Installation
+
+```
+npm i @frctl/loader
+```
+
+## Requirements
+
+`@frctl/loader` requires Node >= v7.6

--- a/packages/internals/loader/index.js
+++ b/packages/internals/loader/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/loader');

--- a/packages/internals/loader/index.test.js
+++ b/packages/internals/loader/index.test.js
@@ -1,0 +1,9 @@
+const {expect} = require('../../../test/helpers');
+const Loader = require('./src/loader');
+const main = require('.');
+
+describe('main', function () {
+  it('exports the loader class', function () {
+    expect(main).to.equal(Loader);
+  });
+});

--- a/packages/internals/loader/package.json
+++ b/packages/internals/loader/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@frctl/loader",
+  "description": "Alias-able module loader for Fractal",
+  "version": "2.0.0-beta.0",
+  "homepage": "http://fractal.build",
+  "repository": "https://github.com/frctl/fractal/tree/v2/packages/loader",
+  "bugs": "https://github.com/frctl/fractal/issues",
+  "author": "Mark Perkins <mark@allmarkedup.com> (http://allmarkedup.com)",
+  "license": "MIT",
+  "dependencies": {
+    "enhanced-resolve": "^3.1.0"
+  }
+}

--- a/packages/internals/loader/package.json
+++ b/packages/internals/loader/package.json
@@ -8,6 +8,7 @@
   "author": "Mark Perkins <mark@allmarkedup.com> (http://allmarkedup.com)",
   "license": "MIT",
   "dependencies": {
-    "enhanced-resolve": "^3.1.0"
+    "enhanced-resolve": "^3.4.1",
+    "@frctl/utils": "^2.0.0-beta.0"
   }
 }

--- a/packages/internals/loader/src/loader.js
+++ b/packages/internals/loader/src/loader.js
@@ -1,0 +1,6 @@
+
+class Loader {
+
+}
+
+module.exports = Loader;

--- a/packages/internals/loader/src/loader.js
+++ b/packages/internals/loader/src/loader.js
@@ -22,8 +22,12 @@ class Loader {
   resolve(path, root) {
     try {
       return this.resolver.resolveSync({}, root || process.cwd(), path);
-    } catch (err) {
-      return require.resolve(path);
+    } catch (resolverError) {
+      try {
+        return require.resolve(path);
+      } catch (nativeError) {
+        throw new Error(`Could not resolve module ${path} [resolver-error]\n${resolverError.message}\n${nativeError.message}`);
+      }
     }
   }
 

--- a/packages/internals/loader/src/loader.js
+++ b/packages/internals/loader/src/loader.js
@@ -1,5 +1,35 @@
+/* eslint import/no-dynamic-require: off */
+
+const {defaultsDeep} = require('@frctl/utils');
+const {NodeJsInputFileSystem, CachedInputFileSystem, ResolverFactory} = require('enhanced-resolve');
+
+const _resolver = new WeakMap();
 
 class Loader {
+
+  constructor(config = {}) {
+    const opts = defaultsDeep(config, {
+      useSyncFileSystemCalls: true,
+      fileSystem: new CachedInputFileSystem(new NodeJsInputFileSystem(), 4000)
+    });
+    _resolver.set(this, ResolverFactory.createResolver(opts));
+  }
+
+  require(path, root) {
+    return require(this.resolve(path, root));
+  }
+
+  resolve(path, root) {
+    try {
+      return this.resolver.resolveSync({}, root || process.cwd(), path);
+    } catch (err) {
+      return require.resolve(path);
+    }
+  }
+
+  get resolver() {
+    return _resolver.get(this);
+  }
 
 }
 

--- a/packages/internals/loader/src/loader.test.js
+++ b/packages/internals/loader/src/loader.test.js
@@ -1,0 +1,74 @@
+const {join} = require('path');
+const Resolver = require('enhanced-resolve/lib/Resolver');
+const {ResolverFactory} = require('enhanced-resolve');
+const {expect, sinon} = require('../../../../test/helpers');
+const Loader = require('./loader');
+
+describe('Loader', function () {
+  describe('constructor()', function () {
+    it('passes configuration options to the resolver', function () {
+      const spy = sinon.spy(ResolverFactory, 'createResolver');
+      // eslint-disable-next-line no-unused-vars
+      const loader = new Loader({
+        fileSystem: 'foo'
+      });
+      expect(spy.args[0][0].fileSystem).to.equal('foo');
+      spy.restore();
+    });
+  });
+
+  describe('.resolve()', function () {
+    it('synchronously resolves the path with respect to the root', function () {
+      const loader = new Loader();
+      expect(loader.resolve('./loader', __dirname)).to.equal(join(__dirname, 'loader.js'));
+    });
+
+    it('resolved paths relative to the cwd if no root is supplied', function () {
+      const loader = new Loader();
+      const result = loader.resolve('./test/fixtures/add-ons/plugin');
+      expect(result).to.equal(join(process.cwd(), 'test/fixtures/add-ons/plugin.js'));
+    });
+
+    it('throws an error if the path cannot be resolved', function () {
+      const loader = new Loader();
+      expect(() => loader.resolve('./foo', __dirname)).to.throw();
+    });
+
+    it('falls back to native node resolution if the path cannot be resolved', function () {
+      const loader = new Loader();
+      expect(loader.resolve('fs')).to.equal(require.resolve('fs'));
+    });
+
+    it('resolves paths against any aliases supplied in config', function () {
+      const loader = new Loader({
+        alias: {
+          '@@': __dirname,
+          '!': process.cwd()
+        }
+      });
+      expect(loader.resolve('@@/loader.js')).to.equal(join(__dirname, 'loader.js'));
+      expect(loader.resolve('!/README.md')).to.equal(join(process.cwd(), 'README.md'));
+    });
+  });
+
+  describe('.require()', function () {
+    it('requires a module after resolving the path', function () {
+      const loader = new Loader();
+      const spy = sinon.spy(loader, 'resolve');
+      loader.require('./loader', __dirname);
+      expect(spy.calledWith('./loader', __dirname)).to.equal(true);
+    });
+
+    it('throws an error if the module cannot be required', function () {
+      const loader = new Loader();
+      expect(() => loader.require('./foo', __dirname)).to.throw();
+    });
+  });
+
+  describe('.resolver', function () {
+    it('returns the internal resolver instance', function () {
+      const loader = new Loader();
+      expect(loader.resolver).to.be.instanceOf(Resolver);
+    });
+  });
+});

--- a/packages/internals/loader/src/loader.test.js
+++ b/packages/internals/loader/src/loader.test.js
@@ -31,7 +31,7 @@ describe('Loader', function () {
 
     it('throws an error if the path cannot be resolved', function () {
       const loader = new Loader();
-      expect(() => loader.resolve('./foo', __dirname)).to.throw();
+      expect(() => loader.resolve('./foo', __dirname)).to.throw('[resolver-error]');
     });
 
     it('falls back to native node resolution if the path cannot be resolved', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,9 +1061,24 @@ enhance-visitors@^1.0.0:
   dependencies:
     lodash "^4.13.1"
 
+enhanced-resolve@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.4.0"
+    object-assign "^4.0.1"
+    tapable "^0.2.7"
+
 entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+errno@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
+  dependencies:
+    prr "~0.0.0"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -2580,6 +2595,13 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memory-fs@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
+  dependencies:
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
+
 meow@^3.3.0, meow@^3.4.2, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -3077,6 +3099,10 @@ proto-props@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/proto-props/-/proto-props-0.2.1.tgz#5e01dc2675a0de9abfa76e799dfa334d6f483f4b"
 
+prr@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+
 pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -3156,7 +3182,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -3676,6 +3702,10 @@ table@^3.7.8:
     lodash "^4.0.0"
     slice-ansi "0.0.4"
     string-width "^2.0.0"
+
+tapable@^0.2.7:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
 
 tar-pack@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
A small wrapper class for Webpack's `enhanced-resolve` that provides support for requiring and resolving modules against a set of path aliases. It will be used to enable path-independent requiring of local modules in Fractal config files (for example, shared data files).