### PR TITLE
Ensure EmittingPromise is exported

### DIFF
--- a/packages/internals/support/index.js
+++ b/packages/internals/support/index.js
@@ -6,3 +6,4 @@ module.exports.FileCollection = require('./src/file-collection');
 module.exports.Component = require('./src/component');
 module.exports.Variant = require('./src/variant');
 module.exports.Emitter = require('./src/emitter');
+module.exports.EmittingPromise = require('./src/emitting-promise');

--- a/packages/internals/support/index.test.js
+++ b/packages/internals/support/index.test.js
@@ -10,7 +10,8 @@ const srcExports = {
   Component: require('./src/component'),
   Variant: require('./src/variant'),
   Emitter: require('./src/emitter'),
-  EmittingPromise: require('./src/emitting-promise')
+  EmittingPromise: require('./src/emitting-promise'),
+  Validator: require('./src/validator')
 };
 
 describe('Support exports', function () {

--- a/packages/internals/support/index.test.js
+++ b/packages/internals/support/index.test.js
@@ -9,12 +9,13 @@ const srcExports = {
   FileCollection: require('./src/file-collection'),
   Component: require('./src/component'),
   Variant: require('./src/variant'),
-  Emitter: require('./src/emitter')
+  Emitter: require('./src/emitter'),
+  EmittingPromise: require('./src/emitting-promise')
 };
 
 describe('Support exports', function () {
   it('exports all support classes', function () {
-    Object.keys(srcExports).forEach(key => {
+    Object.keys(main).forEach(key => {
       expect(main[key]).to.equal(srcExports[key]);
     });
   });

--- a/packages/internals/support/src/collection.test.js
+++ b/packages/internals/support/src/collection.test.js
@@ -624,7 +624,9 @@ describe('Collection', function () {
   });
 
   describe('[Symbol.toStringTag]', function () {
-    const collection = makeCollection();
-    expect(collection[Symbol.toStringTag]).to.equal('Collection');
+    it('should resolve correctly', function () {
+      const collection = makeCollection();
+      expect(collection[Symbol.toStringTag]).to.equal('Collection');
+    });
   });
 });

--- a/packages/internals/support/src/component-collection.test.js
+++ b/packages/internals/support/src/component-collection.test.js
@@ -140,7 +140,9 @@ describe('ComponentCollection', function () {
   });
 
   describe('[Symbol.toStringTag]', function () {
-    const collection = makeCollection();
-    expect(collection[Symbol.toStringTag]).to.equal('ComponentCollection');
+    it('should resolve correctly', function () {
+      const collection = makeCollection();
+      expect(collection[Symbol.toStringTag]).to.equal('ComponentCollection');
+    });
   });
 });

--- a/packages/internals/support/src/component.test.js
+++ b/packages/internals/support/src/component.test.js
@@ -95,7 +95,9 @@ describe('Component', function () {
     });
   });
   describe('[Symbol.toStringTag]', function () {
-    const component = new Component(basicComponent);
-    expect(component[Symbol.toStringTag]).to.equal('Component');
+    it('should resolve correctly', function () {
+      const component = new Component(basicComponent);
+      expect(component[Symbol.toStringTag]).to.equal('Component');
+    });
   });
 });

--- a/packages/internals/support/src/emitting-promise.js
+++ b/packages/internals/support/src/emitting-promise.js
@@ -31,5 +31,10 @@ class EmittingPromise extends Promise {
 
     this.emitter = emitter;
   }
+
+  get [Symbol.toStringTag]() {
+    return 'EmittingPromise';
+  }
+
 }
 module.exports = EmittingPromise;

--- a/packages/internals/support/src/emitting-promise.test.js
+++ b/packages/internals/support/src/emitting-promise.test.js
@@ -35,7 +35,9 @@ describe('EmittingPromise', function () {
       return eProm;
     });
     it('proxies to its emitter properly', function () {
-      const eventEmitter = new EventEmitter2({wildcard: true});
+      const eventEmitter = new EventEmitter2({
+        wildcard: true
+      });
       const eProm = new EmittingPromise(basicResolver);
       const spies = {};
       for (let prop in eventEmitter) {
@@ -81,19 +83,19 @@ describe('EmittingPromise', function () {
   describe('.reject()/.catch()', function () {
     it('rejects as expected on catch prop', function () {
       return new EmittingPromise((resolve, reject) =>
-      reject(new Error('failed to deliver on my promise to you')))
-      .catch(err => {
-        expect(err).to.exist;
-      });
+          reject(new Error('failed to deliver on my promise to you')))
+        .catch(err => {
+          expect(err).to.exist;
+        });
     });
     it('rejects as expected as second param', function () {
       return new EmittingPromise((resolve, reject) =>
-      reject(new Error('failed to deliver on my promise to you')))
-      .then(res => {
-        console.log(res);
-      }, err => {
-        expect(err).to.exist;
-      });
+          reject(new Error('failed to deliver on my promise to you')))
+        .then(res => {
+          console.log(res);
+        }, err => {
+          expect(err).to.exist;
+        });
     });
   });
   describe('emitting and resolving', function () {
@@ -108,6 +110,13 @@ describe('EmittingPromise', function () {
         expect(result).to.equal('very final value');
       }).catch(err => console.log(err));
 
+      return eProm;
+    });
+  });
+  describe('[Symbol.toStringTag]', function () {
+    it('should resolve correctly', function () {
+      const eProm = new EmittingPromise(resolver);
+      expect(eProm[Symbol.toStringTag]).to.equal('EmittingPromise');
       return eProm;
     });
   });

--- a/packages/internals/support/src/entity.test.js
+++ b/packages/internals/support/src/entity.test.js
@@ -108,7 +108,9 @@ describe('Entity', function () {
     });
   });
   describe('[Symbol.toStringTag]', function () {
-    const entity = makeEntity();
-    expect(entity[Symbol.toStringTag]).to.equal('Entity');
+    it('should resolve correctly', function () {
+      const entity = makeEntity();
+      expect(entity[Symbol.toStringTag]).to.equal('Entity');
+    });
   });
 });

--- a/packages/internals/support/src/file-collection.test.js
+++ b/packages/internals/support/src/file-collection.test.js
@@ -85,7 +85,9 @@ describe('FileCollection', function () {
     });
   });
   describe('[Symbol.toStringTag]', function () {
-    const collection = makeCollection();
-    expect(collection[Symbol.toStringTag]).to.equal('FileCollection');
+    it('should resolve correctly', function () {
+      const collection = makeCollection();
+      expect(collection[Symbol.toStringTag]).to.equal('FileCollection');
+    });
   });
 });


### PR DESCRIPTION
Ensure EmittingPromise is exported, and add some fixes to [Symbol.toStringTag] false positive tests