### PR TITLE
Add entity mapping

### DIFF
--- a/packages/internals/parser/test/helpers.js
+++ b/packages/internals/parser/test/helpers.js
@@ -59,10 +59,10 @@ const filesToComponentsTransform = {
     name: 'plugin-status',
     transform: 'files',
     handler: items => items.map(i => {
-        i = i || {};
-        i.ready = true;
-        return i;
-      })
+      i = i || {};
+      i.ready = true;
+      return i;
+    })
   }
 };
 

--- a/packages/internals/parser/test/helpers.js
+++ b/packages/internals/parser/test/helpers.js
@@ -58,9 +58,11 @@ const filesToComponentsTransform = {
   plugins: {
     name: 'plugin-status',
     transform: 'files',
-    handler: items => items.map(i => Object.assign(i, {
-      ready: true
-    }))
+    handler: items => items.map(i => {
+        i = i || {};
+        i.ready = true;
+        return i;
+      })
   }
 };
 

--- a/packages/internals/support/src/collections/collection.js
+++ b/packages/internals/support/src/collections/collection.js
@@ -239,6 +239,7 @@ class Collection {
 
   _getConstr(items, fn) {
     const item = fn(items[0], 0, items);
+    console.log(item);
     assert((check.not.null(item) || check.not.undefined(item)),
       `The mapping funtion supplied returned a 'null' value, please ensure values are filtered before attempting to 'map' a Collection [map-returned-null]`, ReferenceError);
     const Constr = entityMap.get(item.constructor);

--- a/packages/internals/support/src/collections/collection.js
+++ b/packages/internals/support/src/collections/collection.js
@@ -6,6 +6,7 @@ const {cloneDeep} = require('@frctl/utils');
 const check = require('check-types');
 
 const assert = check.assert;
+const entityMap = new Map();
 
 class Collection {
 
@@ -148,7 +149,13 @@ class Collection {
   }
 
   map(...args) {
-    return this._new(this._items.map(...args));
+    let [fn,] = args;
+    const item = fn(this._items[0], 0, this._items);
+    const Constr = entityMap.get(item.constructor);
+    if (Constr) {
+      return new Constr(this._items.map(...args))
+    } 
+    return new Collection(this._items.map(...args));
   }
 
   mapAsync(...args) {
@@ -259,6 +266,15 @@ class Collection {
     return true;
   }
 
+  static addEntityDefinition(key, value) {
+    entityMap.set(key, value);
+  }
+  static getEntityMap() {
+    return entityMap;
+  }
+  static clearEntityMap() {
+    entityMap.clear();
+  }
 }
 
 function iter(...args) {

--- a/packages/internals/support/src/collections/collection.test.js
+++ b/packages/internals/support/src/collections/collection.test.js
@@ -2,19 +2,8 @@
 
 // const path = require('path');
 const {expect, sinon} = require('../../../../../test/helpers');
-const Collection = require('./collection');
-
-const EntityCollection = require('./entity-collection');
-const Entity = require('../entities/entity');
-
-const FileCollection = require('./file-collection');
-const File = require('../entities/file');
-
-const ComponentCollection = require('./component-collection');
-const Component = require('../entities/component');
-
-const VariantCollection = require('./variant-collection');
 const Variant = require('../entities/variant');
+const Collection = require('./collection');
 
 const items = [{
   name: 'mickey',
@@ -74,7 +63,7 @@ function testInstance(newCollection, oldCollection, lItems = items) {
   expect(Collection.isCollection(newCollection)).to.be.true;
 }
 
-describe.only('Collection', function () {
+describe('Collection', function () {
   describe('constructor', function () {
     it('returns an instance from an array that proxies access correctly', function () {
       const collection = makeCollection();
@@ -504,13 +493,6 @@ describe.only('Collection', function () {
   });
 
   describe('.map()', function () {
-    before(function(){
-      Collection.clearEntityMap();
-      Collection.addEntityDefinition(Entity, EntityCollection);
-      Collection.addEntityDefinition(Variant, VariantCollection);
-      Collection.addEntityDefinition(File, FileCollection);
-      Collection.addEntityDefinition(Component, ComponentCollection);
-    });
     it('returns an new Collection', function () {
       const collection = makeCollection();
       let newCollection = collection.map(() => ({src: 'path'}));
@@ -526,45 +508,6 @@ describe.only('Collection', function () {
       expect(function () {
         collection.map(isDogBool).toArray();
       }).to.throw(TypeError, '[items-invalid]');
-    });
-    describe(`Collection`, function(){
-      it(`converts to a ComponentCollection when the map fn returns a Component`, function(){
-        const collection = makeCollection([{src: File.from({ path: '/component/a'})}, {src: File.from({ path: '/component/b'})}, {src: File.from({ path: '/component/c'})}]);
-        let newCollection = collection.map(i => new Component(i));
-        expect(newCollection instanceof ComponentCollection).to.equal(true);
-      });
-      it(`converts to a FileCollection when the map fn returns a File`, function(){
-        const collection = makeCollection([{ path: '/component/a'}, { path: '/component/b'}, { path: '/component/c'}]);
-        let newCollection = collection.map(i => new File(i));
-        expect(newCollection instanceof FileCollection).to.equal(true);
-      });
-      it(`converts to a EntityCollection when the map fn returns a Entity`, function(){
-        const collection = makeCollection([{ path: '/component/a'}, { path: '/component/b'}, { path: '/component/c'}]);
-        let newCollection = collection.map(i => new Entity(i));
-        expect(newCollection instanceof EntityCollection).to.equal(true);
-      });
-      it(`converts to a VariantCollection when the map fn returns a Variant`, function(){
-        const collection = makeCollection([{
-          name: 'variant-1',
-          component: 'parent-component'
-        }, {
-          name: 'variant-2',
-          component: 'parent-component'
-        }, {
-          name: 'variant-3',
-          component: 'parent-component'
-        }]);
-        let newCollection = collection.map(i => new Variant(i));
-        expect(newCollection instanceof VariantCollection).to.equal(true);
-      });
-    });
-    describe(`ComponentCollection`, function(){
-      it(`converts to a Collection when the map fn returns an Object`, function(){
-        const collection = new ComponentCollection([{src: File.from({ path: '/component/a'})}, {src: File.from({ path: '/component/b'})}, {src: File.from({ path: '/component/c'})}]);
-        let newCollection = collection.map(i => ({ src: i.src, foo: 'bar'}));
-        expect(newCollection instanceof ComponentCollection).to.equal(false);
-        expect(newCollection instanceof Collection).to.equal(true);
-      });
     });
   });
 
@@ -705,16 +648,11 @@ describe.only('Collection', function () {
   });
 
   describe('.addEntityDefinition()', function () {
-    before(function(){
-      Collection.clearEntityMap();
-    });
     it('adds specified values to the Entity map', function () {
       const entityMap = Collection.getEntityMap();
-      expect(entityMap.size).to.equal(0);
+      expect(entityMap.size).to.equal(4);
       Collection.addEntityDefinition(Object, Collection);
-      expect(entityMap.size).to.equal(1);
-      Collection.addEntityDefinition(Entity, EntityCollection);
-      expect(entityMap.size).to.equal(2);
+      expect(entityMap.size).to.equal(5);
     });
   });
 

--- a/packages/internals/support/src/collections/collection.test.js
+++ b/packages/internals/support/src/collections/collection.test.js
@@ -2,8 +2,19 @@
 
 // const path = require('path');
 const {expect, sinon} = require('../../../../../test/helpers');
-const Variant = require('../entities/variant');
 const Collection = require('./collection');
+
+const EntityCollection = require('./entity-collection');
+const Entity = require('../entities/entity');
+
+const FileCollection = require('./file-collection');
+const File = require('../entities/file');
+
+const ComponentCollection = require('./component-collection');
+const Component = require('../entities/component');
+
+const VariantCollection = require('./variant-collection');
+const Variant = require('../entities/variant');
 
 const items = [{
   name: 'mickey',
@@ -63,7 +74,7 @@ function testInstance(newCollection, oldCollection, lItems = items) {
   expect(Collection.isCollection(newCollection)).to.be.true;
 }
 
-describe('Collection', function () {
+describe.only('Collection', function () {
   describe('constructor', function () {
     it('returns an instance from an array that proxies access correctly', function () {
       const collection = makeCollection();
@@ -493,6 +504,13 @@ describe('Collection', function () {
   });
 
   describe('.map()', function () {
+    before(function(){
+      Collection.clearEntityMap();
+      Collection.addEntityDefinition(Entity, EntityCollection);
+      Collection.addEntityDefinition(Variant, VariantCollection);
+      Collection.addEntityDefinition(File, FileCollection);
+      Collection.addEntityDefinition(Component, ComponentCollection);
+    });
     it('returns an new Collection', function () {
       const collection = makeCollection();
       let newCollection = collection.map(() => ({src: 'path'}));
@@ -508,6 +526,45 @@ describe('Collection', function () {
       expect(function () {
         collection.map(isDogBool).toArray();
       }).to.throw(TypeError, '[items-invalid]');
+    });
+    describe(`Collection`, function(){
+      it(`converts to a ComponentCollection when the map fn returns a Component`, function(){
+        const collection = makeCollection([{src: File.from({ path: '/component/a'})}, {src: File.from({ path: '/component/b'})}, {src: File.from({ path: '/component/c'})}]);
+        let newCollection = collection.map(i => new Component(i));
+        expect(newCollection instanceof ComponentCollection).to.equal(true);
+      });
+      it(`converts to a FileCollection when the map fn returns a File`, function(){
+        const collection = makeCollection([{ path: '/component/a'}, { path: '/component/b'}, { path: '/component/c'}]);
+        let newCollection = collection.map(i => new File(i));
+        expect(newCollection instanceof FileCollection).to.equal(true);
+      });
+      it(`converts to a EntityCollection when the map fn returns a Entity`, function(){
+        const collection = makeCollection([{ path: '/component/a'}, { path: '/component/b'}, { path: '/component/c'}]);
+        let newCollection = collection.map(i => new Entity(i));
+        expect(newCollection instanceof EntityCollection).to.equal(true);
+      });
+      it(`converts to a VariantCollection when the map fn returns a Variant`, function(){
+        const collection = makeCollection([{
+          name: 'variant-1',
+          component: 'parent-component'
+        }, {
+          name: 'variant-2',
+          component: 'parent-component'
+        }, {
+          name: 'variant-3',
+          component: 'parent-component'
+        }]);
+        let newCollection = collection.map(i => new Variant(i));
+        expect(newCollection instanceof VariantCollection).to.equal(true);
+      });
+    });
+    describe(`ComponentCollection`, function(){
+      it(`converts to a Collection when the map fn returns an Object`, function(){
+        const collection = new ComponentCollection([{src: File.from({ path: '/component/a'})}, {src: File.from({ path: '/component/b'})}, {src: File.from({ path: '/component/c'})}]);
+        let newCollection = collection.map(i => ({ src: i.src, foo: 'bar'}));
+        expect(newCollection instanceof ComponentCollection).to.equal(false);
+        expect(newCollection instanceof Collection).to.equal(true);
+      });
     });
   });
 
@@ -644,6 +701,20 @@ describe('Collection', function () {
       const collection = makeCollection([item]);
       collection.clone();
       expect(cloneSpy.called).to.equal(true);
+    });
+  });
+
+  describe('.addEntityDefinition()', function () {
+    before(function(){
+      Collection.clearEntityMap();
+    });
+    it('adds specified values to the Entity map', function () {
+      const entityMap = Collection.getEntityMap();
+      expect(entityMap.size).to.equal(0);
+      Collection.addEntityDefinition(Object, Collection);
+      expect(entityMap.size).to.equal(1);
+      Collection.addEntityDefinition(Entity, EntityCollection);
+      expect(entityMap.size).to.equal(2);
     });
   });
 

--- a/packages/internals/support/src/collections/collection.test.js
+++ b/packages/internals/support/src/collections/collection.test.js
@@ -493,7 +493,7 @@ describe('Collection', function () {
   });
 
   describe('.map()', function () {
-    it('returns an new Collection', function () {
+    it('returns a new Collection', function () {
       const collection = makeCollection();
       let newCollection = collection.map(() => ({src: 'path'}));
       expect(Array.isArray(newCollection)).to.be.false;
@@ -516,7 +516,7 @@ describe('Collection', function () {
   });
 
   describe('.mapAsync()', function () {
-    it('returns an new Collection', async function () {
+    it('returns a new Collection', async function () {
       const collection = makeCollection();
       const resultCollection = await collection.mapAsync(async i => await Promise.resolve(i));
       expect(Array.isArray(resultCollection)).to.be.false;
@@ -543,7 +543,7 @@ describe('Collection', function () {
   });
 
   describe('.mapToArray()', function () {
-    it('returns an new Array from a mapped Collection', function () {
+    it('returns a new Array from a mapped Collection', function () {
       const collection = makeCollection();
       let newArray = collection.mapToArray(i => i);
       expect(Array.isArray(newArray)).to.be.true;
@@ -557,7 +557,7 @@ describe('Collection', function () {
   });
 
   describe('.mapToArrayAsync()', function () {
-    it('returns an new Collection', function () {
+    it('returns a new Collection', function () {
       const collection = makeCollection();
       return collection.mapToArrayAsync(() => ({})).then(function (resultArray) {
         expect(Array.isArray(resultArray)).to.be.true;

--- a/packages/internals/support/src/collections/collection.test.js
+++ b/packages/internals/support/src/collections/collection.test.js
@@ -509,30 +509,36 @@ describe('Collection', function () {
         collection.map(isDogBool).toArray();
       }).to.throw(TypeError, '[items-invalid]');
     });
+    it(`outputs an empty Collection if an empty Collection is input`, function () {
+      const collection = makeCollection([]);
+      expect(collection.map(isDogBool)).to.be.a('Collection').and.to.include({length: 0});
+    });
   });
 
   describe('.mapAsync()', function () {
-    it('returns an new Collection', function () {
+    it('returns an new Collection', async function () {
       const collection = makeCollection();
-      return collection.mapAsync(i => i).then(function (resultCollection) {
-        expect(Array.isArray(resultCollection)).to.be.false;
-        testInstance(resultCollection, collection);
-      });
+      const resultCollection = await collection.mapAsync(async i => await Promise.resolve(i));
+      expect(Array.isArray(resultCollection)).to.be.false;
+      testInstance(resultCollection, collection);
     });
-    it('returns a collection where each item has been run through the provided mapper', function () {
+    it('returns a collection where each item has been run through the provided mapper', async function () {
       const collection = makeCollection();
-      return collection.mapAsync(isDogObj).then(function (resultCollection) {
-        expect(resultCollection.toArray()).to.eql(items.map(isDogObj));
-      });
+      const resultCollection = await collection.mapAsync(i => new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve({isDog: i.type === 'dog'});
+        }, 200);
+      }));
+      expect(resultCollection.toArray()).to.eql(items.map(isDogObj));
     });
-    it(`errors if the mapper doesn't return an Object`, function () {
+    it(`errors if the mapper doesn't return an Object`, async function () {
       const collection = makeCollection();
-      return collection.mapAsync(isDogBool).then(
-        function (resultCollection) {},
-        function (error) {
-          expect(error instanceof TypeError).to.be.true;
-          expect(error.message).to.match(/\[items-invalid\]/);
-        });
+      try {
+        await collection.mapAsync(async i => await Promise.resolve(i.type === 'dog'));
+      } catch (err) {
+        expect(err instanceof TypeError).to.be.true;
+        expect(err.message).to.match(/\[items-invalid\]/);
+      }
     });
   });
 

--- a/packages/internals/support/src/collections/component-collection.js
+++ b/packages/internals/support/src/collections/component-collection.js
@@ -3,6 +3,7 @@ const check = require('check-types');
 const slash = require('slash');
 const Component = require('../entities/component');
 const EntityCollection = require('./entity-collection');
+const Collection = require('./collection');
 
 const assert = check.assert;
 
@@ -63,4 +64,7 @@ class ComponentCollection extends EntityCollection {
   }
 
 }
+
+Collection.addEntityDefinition(Component, ComponentCollection);
+
 module.exports = ComponentCollection;

--- a/packages/internals/support/src/collections/entity-collection.js
+++ b/packages/internals/support/src/collections/entity-collection.js
@@ -29,4 +29,7 @@ class EntityCollection extends Collection {
   }
 
 }
+
+Collection.addEntityDefinition(Entity, EntityCollection);
+
 module.exports = EntityCollection;

--- a/packages/internals/support/src/collections/file-collection.js
+++ b/packages/internals/support/src/collections/file-collection.js
@@ -3,6 +3,7 @@ const check = require('check-types');
 const slash = require('slash');
 const File = require('../entities/file');
 const EntityCollection = require('./entity-collection');
+const Collection = require('./collection');
 
 const assert = check.assert;
 
@@ -50,4 +51,7 @@ class FileCollection extends EntityCollection {
     return check.maybe.array.of.instance(items, File);
   }
 }
+
+Collection.addEntityDefinition(File, FileCollection);
+
 module.exports = FileCollection;

--- a/packages/internals/support/src/collections/variant-collection.js
+++ b/packages/internals/support/src/collections/variant-collection.js
@@ -2,6 +2,7 @@ const {uniqueName} = require('@frctl/utils');
 const check = require('check-types');
 const Variant = require('../entities/variant');
 const EntityCollection = require('./entity-collection');
+const Collection = require('./collection');
 
 const assert = check.assert;
 
@@ -152,5 +153,7 @@ function createVariant(target, props = {}) {
   variant = Variant.from(variant);
   return variant;
 }
+
+Collection.addEntityDefinition(Variant, VariantCollection);
 
 module.exports = VariantCollection;

--- a/packages/internals/support/src/entities/entity.js
+++ b/packages/internals/support/src/entities/entity.js
@@ -26,7 +26,7 @@ class Entity {
           return target.get(propKey);
         }
         const originalProp = Reflect.get(target, propKey);
-        if (typeof originalProp === 'function') {
+        if ((typeof originalProp === 'function') && (propKey !== 'constructor')) {
           return originalProp.bind(target);
         }
         return originalProp;

--- a/packages/internals/support/test/collection-maps.test.js
+++ b/packages/internals/support/test/collection-maps.test.js
@@ -120,26 +120,26 @@ describe('Collection Mapping', function () {
       testCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
     });
 
-    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+    it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestCtoCCollection(makeFileCollection(validFileDefs), async i => await new Component({
         src: i
       }), FileCollection, ComponentCollection);
     });
-    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+    it(`asyncronously converts to a FileCollection when mapAsync returns a File`, async function () {
       await asyncTestAtoACollection(makeFileCollection(validFileDefs), fileMap, FileCollection, FileCollection);
     });
-    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+    it(`asyncronously converts to a EntityCollection when mapAsync returns an Entity`, async function () {
       await asyncTestCtoACollection(makeFileCollection(validFileDefs), async i => await Promise.resolve(new Entity({
         src: i.stem
       })), FileCollection, EntityCollection);
     });
-    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+    it(`asyncronously converts to a VariantCollection when mapAsync returns a Variant`, async function () {
       await asyncTestCtoCCollection(makeFileCollection(validFileDefs), async i => await Promise.resolve(new Variant({
         name: i.stem,
         component: 'parent-component'
       })), FileCollection, VariantCollection);
     });
-    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+    it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
     });
   });
@@ -166,24 +166,24 @@ describe('Collection Mapping', function () {
       testCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
     });
 
-    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+    it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), async i => await Promise.resolve(new Component({
         src: new File(i)
       })), EntityCollection, ComponentCollection);
     });
-    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+    it(`asyncronously converts to a FileCollection when mapAsync returns a File`, async function () {
       await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), fileMap, EntityCollection, FileCollection);
     });
-    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+    it(`asyncronously converts to a EntityCollection when mapAsync returns an Entity`, async function () {
       await asyncTestAtoACollection(makeEntityCollection(validEntityDefs), entityMap, EntityCollection, EntityCollection);
     });
-    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+    it(`asyncronously converts to a VariantCollection when mapAsync returns a Variant`, async function () {
       await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), async i => await Promise.resolve(new Variant({
         name: i.path,
         component: 'parent-component'
       })), EntityCollection, VariantCollection);
     });
-    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+    it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
     });
   });
@@ -207,21 +207,21 @@ describe('Collection Mapping', function () {
       testCtoACollection(makeVariantCollection(validVariantDefs), objectMap, VariantCollection, Collection);
     });
 
-    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+    it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), async i => await Promise.resolve(new Component({src: new File({path: i.name})})), VariantCollection, ComponentCollection);
     });
-    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+    it(`asyncronously converts to a FileCollection when mapAsync returns a File`, async function () {
       await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), async i => await Promise.resolve(new File({path: i.name})), VariantCollection, FileCollection);
     });
-    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+    it(`asyncronously converts to a EntityCollection when mapAsync returns an Entity`, async function () {
       await asyncTestCtoACollection(makeVariantCollection(validVariantDefs), async i => await Promise.resolve(new Entity({
         src: i.name
       })), VariantCollection, EntityCollection);
     });
-    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+    it(`asyncronously converts to a VariantCollection when mapAsync returns a Variant`, async function () {
       await asyncTestAtoACollection(makeVariantCollection(validVariantDefs), variantMap, VariantCollection, VariantCollection);
     });
-    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+    it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeVariantCollection(validVariantDefs), objectMap, VariantCollection, Collection);
     });
   });
@@ -243,19 +243,19 @@ describe('Collection Mapping', function () {
       testAtoACollection(makeCollection(validComponentDefs), objectMap, Collection, Collection);
     });
 
-    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+    it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestAtoCCollection(makeCollection(validComponentDefs), componentMap, Collection, ComponentCollection);
     });
-    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+    it(`asyncronously converts to a FileCollection when mapAsync returns a File`, async function () {
       await asyncTestAtoCCollection(makeCollection(validFileDefs), fileMap, Collection, FileCollection);
     });
-    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+    it(`asyncronously converts to a EntityCollection when mapAsync returns an Entity`, async function () {
       await asyncTestAtoCCollection(makeCollection(validEntityDefs), entityMap, Collection, EntityCollection);
     });
-    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+    it(`asyncronously converts to a VariantCollection when mapAsync returns a Variant`, async function () {
       await asyncTestAtoCCollection(makeCollection(validVariantDefs), variantMap, Collection, VariantCollection);
     });
-    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+    it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestAtoACollection(makeCollection(validComponentDefs), objectMap, Collection, Collection);
     });
   });

--- a/packages/internals/support/test/collection-maps.test.js
+++ b/packages/internals/support/test/collection-maps.test.js
@@ -73,6 +73,9 @@ describe('Collection Mapping', function () {
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testCtoACollection(makeComponentCollection(validComponentDefs), objectMap, ComponentCollection, Collection);
     });
+    it(`syncronously returns a ComponentCollection if an empty ComponentCollection is supplied`, function () {
+      testAtoACollection(makeComponentCollection([]), objectMap, ComponentCollection, ComponentCollection);
+    });
 
     it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestAtoACollection(makeComponentCollection(validComponentDefs), componentMap, ComponentCollection, ComponentCollection);
@@ -93,6 +96,12 @@ describe('Collection Mapping', function () {
     });
     it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeComponentCollection(validComponentDefs), objectMap, ComponentCollection, Collection);
+    });
+    it(`asyncronously returns a ComponentCollection if an empty ComponentCollection is supplied`, async function () {
+      await asyncTestAtoACollection(makeComponentCollection([]), async i => await Promise.resolve(new Variant({
+        name: i.getSrc().stem,
+        component: 'parent-component'
+      })), ComponentCollection, ComponentCollection);
     });
   });
 
@@ -119,6 +128,9 @@ describe('Collection Mapping', function () {
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
     });
+    it(`syncronously returns a FileCollection if an empty FileCollection is supplied`, function () {
+      testAtoACollection(makeFileCollection([]), objectMap, FileCollection, Collection);
+    });
 
     it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestCtoCCollection(makeFileCollection(validFileDefs), async i => await new Component({
@@ -141,6 +153,12 @@ describe('Collection Mapping', function () {
     });
     it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
+    });
+    it(`asyncronously returns a FileCollection if an empty FileCollection is supplied`, async function () {
+      await asyncTestAtoACollection(makeFileCollection([]), async i => await Promise.resolve(new Variant({
+        name: i.stem,
+        component: 'parent-component'
+      })), FileCollection, FileCollection);
     });
   });
 
@@ -165,6 +183,9 @@ describe('Collection Mapping', function () {
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
     });
+    it(`syncronously returns an EntityCollection when an empty EntityCollection is provided`, function () {
+      testAtoACollection(makeEntityCollection([]), objectMap, EntityCollection, EntityCollection);
+    });
 
     it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), async i => await Promise.resolve(new Component({
@@ -186,6 +207,11 @@ describe('Collection Mapping', function () {
     it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
     });
+    it(`asyncronously returns an EntityCollection when an empty EntityCollection is provided`, async function () {
+      await asyncTestAtoACollection(makeEntityCollection([]), async i => await Promise.resolve(new Component({
+        src: new File(i)
+      })), EntityCollection, EntityCollection);
+    });
   });
 
   describe(`VariantCollection`, function () {
@@ -206,6 +232,9 @@ describe('Collection Mapping', function () {
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testCtoACollection(makeVariantCollection(validVariantDefs), objectMap, VariantCollection, Collection);
     });
+    it(`asyncronously returns a VariantCollection when an empty VariantCollection is provided`, function () {
+      testAtoACollection(makeVariantCollection([]), objectMap, VariantCollection, VariantCollection);
+    });
 
     it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), async i => await Promise.resolve(new Component({src: new File({path: i.name})})), VariantCollection, ComponentCollection);
@@ -223,6 +252,9 @@ describe('Collection Mapping', function () {
     });
     it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeVariantCollection(validVariantDefs), objectMap, VariantCollection, Collection);
+    });
+    it(`asyncronously returns a VariantCollection when an empty VariantCollection is provided`, async function () {
+      await asyncTestAtoACollection(makeVariantCollection([]), async i => await Promise.resolve(new Component({src: new File({path: i.name})})), VariantCollection, VariantCollection);
     });
   });
 
@@ -242,6 +274,9 @@ describe('Collection Mapping', function () {
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testAtoACollection(makeCollection(validComponentDefs), objectMap, Collection, Collection);
     });
+    it(`syncronously returns a Collection when an empty Collection is supplied`, function () {
+      testAtoACollection(makeCollection([]), objectMap, Collection, Collection);
+    });
 
     it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
       await asyncTestAtoCCollection(makeCollection(validComponentDefs), componentMap, Collection, ComponentCollection);
@@ -256,7 +291,10 @@ describe('Collection Mapping', function () {
       await asyncTestAtoCCollection(makeCollection(validVariantDefs), variantMap, Collection, VariantCollection);
     });
     it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
-      await asyncTestAtoACollection(makeCollection(validComponentDefs), objectMap, Collection, Collection);
+      await asyncTestAtoACollection(makeCollection(validComponentDefs), async i => await Promise.resolve(Object.assign({}, i)), Collection, Collection);
+    });
+    it(`asyncronously returns a Collection when an empty Collection is supplied`, async function () {
+      await asyncTestAtoACollection(makeCollection(validComponentDefs), async i => await Promise.resolve(Object.assign({}, i)), Collection, Collection);
     });
   });
 });

--- a/packages/internals/support/test/collection-maps.test.js
+++ b/packages/internals/support/test/collection-maps.test.js
@@ -51,53 +51,24 @@ const entityMap = i => new Entity(i);
 const variantMap = i => new Variant(i);
 const objectMap = i => Object.assign({}, i);
 
-const entityFromVariantMap = i => new Entity({
-  src: i.name
-});
-const fileFromVariantMap = i => new File({path: i.name});
-const compFromVariantMap = i => new Component({src: new File({path: i.name})});
-
-const entityFromCompMap = i => new Entity({
-  src: i.getSrc()
-});
-const fileFromCompMap = i => i.getSrc();
-const variantFromCompMap = i => new Variant({
-  name: i.getSrc().stem,
-  component: 'parent-component'
-});
-
-const entityFromFileMap = i => new Entity({
-  src: i.stem
-});
-const compFromFileMap = i => new Component({
-  src: i
-});
-const variantFromFileMap = i => new Variant({
-  name: i.stem,
-  component: 'parent-component'
-});
-
-const compFromEntityMap = i => new Component({
-  src: new File(i)
-});
-const variantFromEntityMap = i => new Variant({
-  name: i.path,
-  component: 'parent-component'
-});
-
 describe('Collection Mapping', function () {
   describe(`ComponentCollection`, function () {
     it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
       testAtoACollection(makeComponentCollection(validComponentDefs), componentMap, ComponentCollection, ComponentCollection);
     });
     it(`syncronously converts to a FileCollection when map returns a File`, function () {
-      testCtoCCollection(makeComponentCollection(validComponentDefs), fileFromCompMap, ComponentCollection, FileCollection);
+      testCtoCCollection(makeComponentCollection(validComponentDefs), i => i.getSrc(), ComponentCollection, FileCollection);
     });
     it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
-      testCtoACollection(makeComponentCollection(validComponentDefs), entityFromCompMap, ComponentCollection, EntityCollection);
+      testCtoACollection(makeComponentCollection(validComponentDefs), i => new Entity({
+        src: i.getSrc()
+      }), ComponentCollection, EntityCollection);
     });
     it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
-      testCtoCCollection(makeComponentCollection(validComponentDefs), variantFromCompMap, ComponentCollection, VariantCollection);
+      testCtoCCollection(makeComponentCollection(validComponentDefs), i => new Variant({
+        name: i.getSrc().stem,
+        component: 'parent-component'
+      }), ComponentCollection, VariantCollection);
     });
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testCtoACollection(makeComponentCollection(validComponentDefs), objectMap, ComponentCollection, Collection);
@@ -107,13 +78,18 @@ describe('Collection Mapping', function () {
       await asyncTestAtoACollection(makeComponentCollection(validComponentDefs), componentMap, ComponentCollection, ComponentCollection);
     });
     it(`asyncronously converts to a FileCollection when mapAsync returns a File`, async function () {
-      await asyncTestCtoCCollection(makeComponentCollection(validComponentDefs), fileFromCompMap, ComponentCollection, FileCollection);
+      await asyncTestCtoCCollection(makeComponentCollection(validComponentDefs), async i => await Promise.resolve(i.getSrc()), ComponentCollection, FileCollection);
     });
     it(`asyncronously converts to a EntityCollection when mapAsync returns an Entity`, async function () {
-      await asyncTestCtoACollection(makeComponentCollection(validComponentDefs), entityFromCompMap, ComponentCollection, EntityCollection);
+      await asyncTestCtoACollection(makeComponentCollection(validComponentDefs), async i => await Promise.resolve(new Entity({
+        src: i.getSrc()
+      })), ComponentCollection, EntityCollection);
     });
     it(`asyncronously converts to a VariantCollection when mapAsync returns a Variant`, async function () {
-      await asyncTestCtoCCollection(makeComponentCollection(validComponentDefs), variantFromCompMap, ComponentCollection, VariantCollection);
+      await asyncTestCtoCCollection(makeComponentCollection(validComponentDefs), async i => await Promise.resolve(new Variant({
+        name: i.getSrc().stem,
+        component: 'parent-component'
+      })), ComponentCollection, VariantCollection);
     });
     it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
       await asyncTestCtoACollection(makeComponentCollection(validComponentDefs), objectMap, ComponentCollection, Collection);
@@ -122,32 +98,46 @@ describe('Collection Mapping', function () {
 
   describe(`FileCollection`, function () {
     it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
-      testCtoCCollection(makeFileCollection(validFileDefs), compFromFileMap, FileCollection, ComponentCollection);
+      testCtoCCollection(makeFileCollection(validFileDefs), i => new Component({
+        src: i
+      }), FileCollection, ComponentCollection);
     });
     it(`syncronously converts to a FileCollection when map returns a File`, function () {
       testAtoACollection(makeFileCollection(validFileDefs), fileMap, FileCollection, FileCollection);
     });
     it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
-      testCtoACollection(makeFileCollection(validFileDefs), entityFromFileMap, FileCollection, EntityCollection);
+      testCtoACollection(makeFileCollection(validFileDefs), i => new Entity({
+        src: i.stem
+      }), FileCollection, EntityCollection);
     });
     it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
-      testCtoCCollection(makeFileCollection(validFileDefs), variantFromFileMap, FileCollection, VariantCollection);
+      testCtoCCollection(makeFileCollection(validFileDefs), i => new Variant({
+        name: i.stem,
+        component: 'parent-component'
+      }), FileCollection, VariantCollection);
     });
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
     });
 
     it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
-      await asyncTestCtoCCollection(makeFileCollection(validFileDefs), compFromFileMap, FileCollection, ComponentCollection);
+      await asyncTestCtoCCollection(makeFileCollection(validFileDefs), async i => await new Component({
+        src: i
+      }), FileCollection, ComponentCollection);
     });
     it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
       await asyncTestAtoACollection(makeFileCollection(validFileDefs), fileMap, FileCollection, FileCollection);
     });
     it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
-      await asyncTestCtoACollection(makeFileCollection(validFileDefs), entityFromFileMap, FileCollection, EntityCollection);
+      await asyncTestCtoACollection(makeFileCollection(validFileDefs), async i => await Promise.resolve(new Entity({
+        src: i.stem
+      })), FileCollection, EntityCollection);
     });
     it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
-      await asyncTestCtoCCollection(makeFileCollection(validFileDefs), variantFromFileMap, FileCollection, VariantCollection);
+      await asyncTestCtoCCollection(makeFileCollection(validFileDefs), async i => await Promise.resolve(new Variant({
+        name: i.stem,
+        component: 'parent-component'
+      })), FileCollection, VariantCollection);
     });
     it(`asyncronously converts to a Collection when map returns an Object`, async function () {
       await asyncTestCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
@@ -156,7 +146,9 @@ describe('Collection Mapping', function () {
 
   describe(`EntityCollection`, function () {
     it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
-      testAtoCCollection(makeEntityCollection(validEntityDefs), compFromEntityMap, EntityCollection, ComponentCollection);
+      testAtoCCollection(makeEntityCollection(validEntityDefs), i => new Component({
+        src: new File(i)
+      }), EntityCollection, ComponentCollection);
     });
     it(`syncronously converts to a FileCollection when map returns a File`, function () {
       testAtoCCollection(makeEntityCollection(validEntityDefs), fileMap, EntityCollection, FileCollection);
@@ -165,14 +157,19 @@ describe('Collection Mapping', function () {
       testAtoACollection(makeEntityCollection(validEntityDefs), entityMap, EntityCollection, EntityCollection);
     });
     it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
-      testAtoCCollection(makeEntityCollection(validEntityDefs), variantFromEntityMap, EntityCollection, VariantCollection);
+      testAtoCCollection(makeEntityCollection(validEntityDefs), i => new Variant({
+        name: i.path,
+        component: 'parent-component'
+      }), EntityCollection, VariantCollection);
     });
     it(`syncronously converts to a Collection when map returns an Object`, function () {
       testCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
     });
 
     it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
-      await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), compFromEntityMap, EntityCollection, ComponentCollection);
+      await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), async i => await Promise.resolve(new Component({
+        src: new File(i)
+      })), EntityCollection, ComponentCollection);
     });
     it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
       await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), fileMap, EntityCollection, FileCollection);
@@ -181,7 +178,10 @@ describe('Collection Mapping', function () {
       await asyncTestAtoACollection(makeEntityCollection(validEntityDefs), entityMap, EntityCollection, EntityCollection);
     });
     it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
-      await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), variantFromEntityMap, EntityCollection, VariantCollection);
+      await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), async i => await Promise.resolve(new Variant({
+        name: i.path,
+        component: 'parent-component'
+      })), EntityCollection, VariantCollection);
     });
     it(`asyncronously converts to a Collection when map returns an Object`, async function () {
       await asyncTestCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
@@ -190,13 +190,15 @@ describe('Collection Mapping', function () {
 
   describe(`VariantCollection`, function () {
     it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
-      testCtoCCollection(makeVariantCollection(validVariantDefs), compFromVariantMap, VariantCollection, ComponentCollection);
+      testCtoCCollection(makeVariantCollection(validVariantDefs), i => new Component({src: new File({path: i.name})}), VariantCollection, ComponentCollection);
     });
     it(`syncronously converts to a FileCollection when map returns a File`, function () {
-      testCtoCCollection(makeVariantCollection(validVariantDefs), fileFromVariantMap, VariantCollection, FileCollection);
+      testCtoCCollection(makeVariantCollection(validVariantDefs), i => new File({path: i.name}), VariantCollection, FileCollection);
     });
     it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
-      testCtoACollection(makeVariantCollection(validVariantDefs), entityFromVariantMap, VariantCollection, EntityCollection);
+      testCtoACollection(makeVariantCollection(validVariantDefs), i => new Entity({
+        src: i.name
+      }), VariantCollection, EntityCollection);
     });
     it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
       testAtoACollection(makeVariantCollection(validVariantDefs), variantMap, VariantCollection, VariantCollection);
@@ -206,13 +208,15 @@ describe('Collection Mapping', function () {
     });
 
     it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
-      await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), compFromVariantMap, VariantCollection, ComponentCollection);
+      await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), async i => await Promise.resolve(new Component({src: new File({path: i.name})})), VariantCollection, ComponentCollection);
     });
     it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
-      await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), fileFromVariantMap, VariantCollection, FileCollection);
+      await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), async i => await Promise.resolve(new File({path: i.name})), VariantCollection, FileCollection);
     });
     it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
-      await asyncTestCtoACollection(makeVariantCollection(validVariantDefs), entityFromVariantMap, VariantCollection, EntityCollection);
+      await asyncTestCtoACollection(makeVariantCollection(validVariantDefs), async i => await Promise.resolve(new Entity({
+        src: i.name
+      })), VariantCollection, EntityCollection);
     });
     it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
       await asyncTestAtoACollection(makeVariantCollection(validVariantDefs), variantMap, VariantCollection, VariantCollection);

--- a/packages/internals/support/test/collection-maps.test.js
+++ b/packages/internals/support/test/collection-maps.test.js
@@ -1,0 +1,322 @@
+/* eslint no-unused-expressions: "off" */
+
+// const path = require('path');
+const {expect} = require('../../../../test/helpers');
+const Collection = require('../src/collections/collection');
+
+const EntityCollection = require('../src/collections/entity-collection');
+const Entity = require('../src/entities/entity');
+
+const FileCollection = require('../src/collections/file-collection');
+const File = require('../src/entities/file');
+
+const ComponentCollection = require('../src/collections/component-collection');
+const Component = require('../src/entities/component');
+
+const VariantCollection = require('../src/collections/variant-collection');
+const Variant = require('../src/entities/variant');
+
+const makeCollection = input => new Collection(input);
+const makeComponentCollection = input => new ComponentCollection(input);
+const makeVariantCollection = input => new VariantCollection(input);
+const makeFileCollection = input => new FileCollection(input);
+const makeEntityCollection = input => new EntityCollection(input);
+
+const validFileDefs = [{
+  path: '/component/a'
+}, {
+  path: '/component/b'
+}, {
+  path: '/component/c'
+}];
+const validEntityDefs = validFileDefs;
+const validVariantDefs = [{
+  name: 'variant-1',
+  component: 'parent-component'
+}, {
+  name: 'variant-2',
+  component: 'parent-component'
+}, {
+  name: 'variant-3',
+  component: 'parent-component'
+}];
+
+const validComponentDefs = validFileDefs.map(entity => ({
+  src: new File(entity)
+}));
+
+const componentMap = i => new Component(i);
+const fileMap = i => new File(i);
+const entityMap = i => new Entity(i);
+const variantMap = i => new Variant(i);
+const objectMap = i => Object.assign({}, i);
+
+const entityFromVariantMap = i => new Entity({
+  src: i.name
+});
+const fileFromVariantMap = i => new File({path: i.name});
+const compFromVariantMap = i => new Component({src: new File({path: i.name})});
+
+const entityFromCompMap = i => new Entity({
+  src: i.getSrc()
+});
+const fileFromCompMap = i => i.getSrc();
+const variantFromCompMap = i => new Variant({
+  name: i.getSrc().stem,
+  component: 'parent-component'
+});
+
+const entityFromFileMap = i => new Entity({
+  src: i.stem
+});
+const compFromFileMap = i => new Component({
+  src: i
+});
+const variantFromFileMap = i => new Variant({
+  name: i.stem,
+  component: 'parent-component'
+});
+
+const compFromEntityMap = i => new Component({
+  src: new File(i)
+});
+const variantFromEntityMap = i => new Variant({
+  name: i.path,
+  component: 'parent-component'
+});
+
+describe('Collection Mapping', function () {
+  describe(`ComponentCollection`, function () {
+    it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
+      testAtoACollection(makeComponentCollection(validComponentDefs), componentMap, ComponentCollection, ComponentCollection);
+    });
+    it(`syncronously converts to a FileCollection when map returns a File`, function () {
+      testCtoCCollection(makeComponentCollection(validComponentDefs), fileFromCompMap, ComponentCollection, FileCollection);
+    });
+    it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
+      testCtoACollection(makeComponentCollection(validComponentDefs), entityFromCompMap, ComponentCollection, EntityCollection);
+    });
+    it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
+      testCtoCCollection(makeComponentCollection(validComponentDefs), variantFromCompMap, ComponentCollection, VariantCollection);
+    });
+    it(`syncronously converts to a Collection when map returns an Object`, function () {
+      testCtoACollection(makeComponentCollection(validComponentDefs), objectMap, ComponentCollection, Collection);
+    });
+
+    it(`asyncronously converts to a ComponentCollection when mapAsync returns a Component`, async function () {
+      await asyncTestAtoACollection(makeComponentCollection(validComponentDefs), componentMap, ComponentCollection, ComponentCollection);
+    });
+    it(`asyncronously converts to a FileCollection when mapAsync returns a File`, async function () {
+      await asyncTestCtoCCollection(makeComponentCollection(validComponentDefs), fileFromCompMap, ComponentCollection, FileCollection);
+    });
+    it(`asyncronously converts to a EntityCollection when mapAsync returns an Entity`, async function () {
+      await asyncTestCtoACollection(makeComponentCollection(validComponentDefs), entityFromCompMap, ComponentCollection, EntityCollection);
+    });
+    it(`asyncronously converts to a VariantCollection when mapAsync returns a Variant`, async function () {
+      await asyncTestCtoCCollection(makeComponentCollection(validComponentDefs), variantFromCompMap, ComponentCollection, VariantCollection);
+    });
+    it(`asyncronously converts to a Collection when mapAsync returns an Object`, async function () {
+      await asyncTestCtoACollection(makeComponentCollection(validComponentDefs), objectMap, ComponentCollection, Collection);
+    });
+  });
+
+  describe(`FileCollection`, function () {
+    it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
+      testCtoCCollection(makeFileCollection(validFileDefs), compFromFileMap, FileCollection, ComponentCollection);
+    });
+    it(`syncronously converts to a FileCollection when map returns a File`, function () {
+      testAtoACollection(makeFileCollection(validFileDefs), fileMap, FileCollection, FileCollection);
+    });
+    it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
+      testCtoACollection(makeFileCollection(validFileDefs), entityFromFileMap, FileCollection, EntityCollection);
+    });
+    it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
+      testCtoCCollection(makeFileCollection(validFileDefs), variantFromFileMap, FileCollection, VariantCollection);
+    });
+    it(`syncronously converts to a Collection when map returns an Object`, function () {
+      testCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
+    });
+
+    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+      await asyncTestCtoCCollection(makeFileCollection(validFileDefs), compFromFileMap, FileCollection, ComponentCollection);
+    });
+    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+      await asyncTestAtoACollection(makeFileCollection(validFileDefs), fileMap, FileCollection, FileCollection);
+    });
+    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+      await asyncTestCtoACollection(makeFileCollection(validFileDefs), entityFromFileMap, FileCollection, EntityCollection);
+    });
+    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+      await asyncTestCtoCCollection(makeFileCollection(validFileDefs), variantFromFileMap, FileCollection, VariantCollection);
+    });
+    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+      await asyncTestCtoACollection(makeFileCollection(validFileDefs), objectMap, FileCollection, Collection);
+    });
+  });
+
+  describe(`EntityCollection`, function () {
+    it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
+      testAtoCCollection(makeEntityCollection(validEntityDefs), compFromEntityMap, EntityCollection, ComponentCollection);
+    });
+    it(`syncronously converts to a FileCollection when map returns a File`, function () {
+      testAtoCCollection(makeEntityCollection(validEntityDefs), fileMap, EntityCollection, FileCollection);
+    });
+    it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
+      testAtoACollection(makeEntityCollection(validEntityDefs), entityMap, EntityCollection, EntityCollection);
+    });
+    it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
+      testAtoCCollection(makeEntityCollection(validEntityDefs), variantFromEntityMap, EntityCollection, VariantCollection);
+    });
+    it(`syncronously converts to a Collection when map returns an Object`, function () {
+      testCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
+    });
+
+    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+      await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), compFromEntityMap, EntityCollection, ComponentCollection);
+    });
+    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+      await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), fileMap, EntityCollection, FileCollection);
+    });
+    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+      await asyncTestAtoACollection(makeEntityCollection(validEntityDefs), entityMap, EntityCollection, EntityCollection);
+    });
+    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+      await asyncTestAtoCCollection(makeEntityCollection(validEntityDefs), variantFromEntityMap, EntityCollection, VariantCollection);
+    });
+    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+      await asyncTestCtoACollection(makeEntityCollection(validEntityDefs), objectMap, EntityCollection, Collection);
+    });
+  });
+
+  describe(`VariantCollection`, function () {
+    it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
+      testCtoCCollection(makeVariantCollection(validVariantDefs), compFromVariantMap, VariantCollection, ComponentCollection);
+    });
+    it(`syncronously converts to a FileCollection when map returns a File`, function () {
+      testCtoCCollection(makeVariantCollection(validVariantDefs), fileFromVariantMap, VariantCollection, FileCollection);
+    });
+    it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
+      testCtoACollection(makeVariantCollection(validVariantDefs), entityFromVariantMap, VariantCollection, EntityCollection);
+    });
+    it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
+      testAtoACollection(makeVariantCollection(validVariantDefs), variantMap, VariantCollection, VariantCollection);
+    });
+    it(`syncronously converts to a Collection when map returns an Object`, function () {
+      testCtoACollection(makeVariantCollection(validVariantDefs), objectMap, VariantCollection, Collection);
+    });
+
+    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+      await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), compFromVariantMap, VariantCollection, ComponentCollection);
+    });
+    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+      await asyncTestCtoCCollection(makeVariantCollection(validVariantDefs), fileFromVariantMap, VariantCollection, FileCollection);
+    });
+    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+      await asyncTestCtoACollection(makeVariantCollection(validVariantDefs), entityFromVariantMap, VariantCollection, EntityCollection);
+    });
+    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+      await asyncTestAtoACollection(makeVariantCollection(validVariantDefs), variantMap, VariantCollection, VariantCollection);
+    });
+    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+      await asyncTestCtoACollection(makeVariantCollection(validVariantDefs), objectMap, VariantCollection, Collection);
+    });
+  });
+
+  describe(`Collection`, function () {
+    it(`syncronously converts to a ComponentCollection when map returns a Component`, function () {
+      testAtoCCollection(makeCollection(validComponentDefs), componentMap, Collection, ComponentCollection);
+    });
+    it(`syncronously converts to a FileCollection when map returns a File`, function () {
+      testAtoCCollection(makeCollection(validFileDefs), fileMap, Collection, FileCollection);
+    });
+    it(`syncronously converts to a EntityCollection when map returns an Entity`, function () {
+      testAtoCCollection(makeCollection(validEntityDefs), entityMap, Collection, EntityCollection);
+    });
+    it(`syncronously converts to a VariantCollection when map returns a Variant`, function () {
+      testAtoCCollection(makeCollection(validVariantDefs), variantMap, Collection, VariantCollection);
+    });
+    it(`syncronously converts to a Collection when map returns an Object`, function () {
+      testAtoACollection(makeCollection(validComponentDefs), objectMap, Collection, Collection);
+    });
+
+    it(`asyncronously converts to a ComponentCollection when map returns a Component`, async function () {
+      await asyncTestAtoCCollection(makeCollection(validComponentDefs), componentMap, Collection, ComponentCollection);
+    });
+    it(`asyncronously converts to a FileCollection when map returns a File`, async function () {
+      await asyncTestAtoCCollection(makeCollection(validFileDefs), fileMap, Collection, FileCollection);
+    });
+    it(`asyncronously converts to a EntityCollection when map returns an Entity`, async function () {
+      await asyncTestAtoCCollection(makeCollection(validEntityDefs), entityMap, Collection, EntityCollection);
+    });
+    it(`asyncronously converts to a VariantCollection when map returns a Variant`, async function () {
+      await asyncTestAtoCCollection(makeCollection(validVariantDefs), variantMap, Collection, VariantCollection);
+    });
+    it(`asyncronously converts to a Collection when map returns an Object`, async function () {
+      await asyncTestAtoACollection(makeCollection(validComponentDefs), objectMap, Collection, Collection);
+    });
+  });
+});
+
+function testAtoACollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(true);
+  let newCollection = collection.map(map);
+  expect(newCollection instanceof Original).to.equal(true);
+  expect(newCollection instanceof Final).to.equal(true);
+}
+
+function testAtoCCollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(false);
+  let newCollection = collection.map(map);
+  expect(newCollection instanceof Original).to.equal(true);
+  expect(newCollection instanceof Final).to.equal(true);
+}
+
+function testCtoACollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(true);
+  let newCollection = collection.map(map);
+  expect(newCollection instanceof Original).to.equal(false);
+  expect(newCollection instanceof Final).to.equal(true);
+}
+
+function testCtoCCollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(false);
+  let newCollection = collection.map(map);
+  expect(newCollection instanceof Original).to.equal(false);
+  expect(newCollection instanceof Final).to.equal(true);
+}
+
+async function asyncTestAtoACollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(true);
+  let newCollection = await collection.mapAsync(map);
+  expect(newCollection instanceof Original).to.equal(true);
+  expect(newCollection instanceof Final).to.equal(true);
+}
+
+async function asyncTestAtoCCollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(false);
+  let newCollection = await collection.mapAsync(map);
+  expect(newCollection instanceof Original).to.equal(true);
+  expect(newCollection instanceof Final).to.equal(true);
+}
+
+async function asyncTestCtoACollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(true);
+  let newCollection = await collection.mapAsync(map);
+  expect(newCollection instanceof Original).to.equal(false);
+  expect(newCollection instanceof Final).to.equal(true);
+}
+
+async function asyncTestCtoCCollection(collection, map, Original, Final) {
+  expect(collection instanceof Original).to.equal(true);
+  expect(collection instanceof Final).to.equal(false);
+  let newCollection = await collection.mapAsync(map);
+  expect(newCollection instanceof Original).to.equal(false);
+  expect(newCollection instanceof Final).to.equal(true);
+}


### PR DESCRIPTION
Enable automatic mapping of Collections to the correct type, based on the return type of the supplied map function