### PR TITLE
Use new mode API property. Closes #346

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -74,7 +74,7 @@ module.exports = {
 
     writeFile(filePath, data) {
         const pathInfo = Path.parse(Path.resolve(filePath));
-        const format = utils.lang(filePath, true).mode;
+        const format = utils.lang(filePath, true).ace_mode;
         return fs.writeFileAsync(filePath, this.stringify(data, format));
     },
 

--- a/src/core/data.js
+++ b/src/core/data.js
@@ -47,7 +47,7 @@ module.exports = {
     },
 
     readFile(filePath) {
-        const format = utils.lang(filePath, true).mode;
+        const format = utils.lang(filePath, true).ace_mode;
         if (format === 'js' || format === 'javascript') {
             try {
                 filePath = Path.relative(__dirname, filePath);


### PR DESCRIPTION
This fixes the error

```bash
Error loading data file ....config.yml: Cannot read property 'toLowerCase' of undefined
```

in the `$ fractal build` command. Even though I'm still experiencing [this issue](https://github.com/frctl/fractal/issues/160#issuecomment-330337482) when using `$ fractal start --sync`.