### PR TITLE
Component config handling improvements

### DIFF
--- a/packages/fractal/fractal-transform-components/src/transform.test.js
+++ b/packages/fractal/fractal-transform-components/src/transform.test.js
@@ -1,6 +1,7 @@
 /* eslint no-unused-expressions: "off" */
 const fractal = require('@frctl/fractal');
-const {File, FileCollection, Component} = require('@frctl/support');
+const {FileCollection, Component} = require('@frctl/support');
+const {defaultsDeep} = require('@frctl/utils');
 const {expect, sinon} = require('../../../../test/helpers');
 const componentTransform = require('./transform');
 
@@ -81,7 +82,7 @@ const items = [{
 ];
 
 const getFileCollection = () => {
-  return FileCollection.from(items.map(item => File.from(item)));
+  return FileCollection.from(items);
 };
 
 const app = fractal();
@@ -107,12 +108,13 @@ describe('Component Transform', function () {
       expect(output).to.be.a('ComponentCollection');
       expect(output).to.have.property('length').that.equals(3);
     });
-    it('instantiates the component with config merged from config files', async function () {
+    it('instantiates the component with config merged from the config files and the default components config', async function () {
       const spy = sinon.spy(Component, 'from');
-      const fileCollection = FileCollection.from(items.slice(1).map(item => File.from(item)));
+      const fileCollection = FileCollection.from(items.slice(1));
       const transform = componentTransform().transform;
+      const defaults = app.get('components.config.defaults');
       await transform(fileCollection, {}, app);
-      expect(spy.args[1][0].config).to.eql({name: 'config.json', bar: 'baz', foo: 'bar'});
+      expect(spy.args[1][0].config).to.eql(defaultsDeep({name: 'config.json', bar: 'baz', foo: 'bar'}, defaults));
       spy.restore();
     });
   });

--- a/packages/fractal/fractal/src/config/defaults.js
+++ b/packages/fractal/fractal/src/config/defaults.js
@@ -14,19 +14,14 @@ module.exports = {
   },
 
   components: {
-    filter: file => file.stem.startsWith('@')
-  },
-
-  configs: {
-    defaults: {},
-    filter: {
-      stem: 'config'
-    }
-  },
-
-  views: {
-    filter: {
-      stem: 'view'
+    match: file => file.stem.startsWith('@'),
+    config: {
+      defaults: {
+        views: {
+          match: file => file.stem === 'view'
+        }
+      },
+      match: file => file.stem === 'config'
     }
   },
 

--- a/packages/fractal/fractal/src/config/defaults.js
+++ b/packages/fractal/fractal/src/config/defaults.js
@@ -18,10 +18,10 @@ module.exports = {
     config: {
       defaults: {
         views: {
-          match: file => file.stem === 'view'
+          match: 'view.*'
         }
       },
-      match: file => file.stem === 'config'
+      match: 'config.*'
     }
   },
 

--- a/packages/fractal/fractal/src/config/schema.js
+++ b/packages/fractal/fractal/src/config/schema.js
@@ -2,7 +2,7 @@ module.exports = {
 
   type: 'object',
 
-  required: ['configs', 'views'],
+  required: ['components'],
 
   properties: {
 
@@ -31,29 +31,45 @@ module.exports = {
       type: 'object'
     },
 
-    views: {
+    components: {
       type: 'object',
-      required: ['filter'],
+      required: ['config', 'match'],
       properties: {
-        filter: {
+        match: {
           anyOf: [
             {type: 'object'},
             {typeof: 'function'}
           ]
-        }
-      }
-    },
-
-    configs: {
-      type: 'object',
-      required: ['filter', 'defaults'],
-      properties: {
-        defaults: {type: 'object'},
-        filter: {
-          anyOf: [
-            {type: 'object'},
-            {typeof: 'function'}
-          ]
+        },
+        config: {
+          type: 'object',
+          required: ['match', 'defaults'],
+          properties: {
+            defaults: {
+              type: 'object',
+              required: ['views'],
+              properties: {
+                views: {
+                  type: 'object',
+                  required: ['match'],
+                  properties: {
+                    match: {
+                      anyOf: [
+                        {type: 'object'},
+                        {typeof: 'function'}
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            match: {
+              anyOf: [
+                {type: 'object'},
+                {typeof: 'function'}
+              ]
+            }
+          }
         }
       }
     },

--- a/packages/fractal/fractal/src/config/schema.js
+++ b/packages/fractal/fractal/src/config/schema.js
@@ -37,6 +37,7 @@ module.exports = {
       properties: {
         match: {
           anyOf: [
+            {type: 'string'},
             {type: 'object'},
             {typeof: 'function'}
           ]
@@ -55,6 +56,7 @@ module.exports = {
                   properties: {
                     match: {
                       anyOf: [
+                        {type: 'string'},
                         {type: 'object'},
                         {typeof: 'function'}
                       ]
@@ -66,6 +68,7 @@ module.exports = {
             match: {
               anyOf: [
                 {type: 'object'},
+                {type: 'string'},
                 {typeof: 'function'}
               ]
             }

--- a/packages/internals/support/src/collections/collection.test.js
+++ b/packages/internals/support/src/collections/collection.test.js
@@ -615,7 +615,6 @@ describe('Collection', function () {
       const collection = makeCollection();
       try {
         await collection.mapAsync(isDogBoolAsync);
-
       } catch (err) {
         expect(err instanceof TypeError).to.be.true;
         expect(err.message).to.match(/\[items-invalid\]/);

--- a/packages/internals/support/src/collections/file-collection.js
+++ b/packages/internals/support/src/collections/file-collection.js
@@ -11,14 +11,14 @@ class FileCollection extends EntityCollection {
 
   filter(...args) {
     if (args.length === 1 && (typeof args[0] === 'string' || Array.isArray(args[0]))) {
-      return this.filterByPath(...args[0]);
+      return this.filterByPath(...args);
     }
     return new FileCollection(super.filter(...args).toArray());
   }
 
   reject(...args) {
     if (args.length === 1 && (typeof args[0] === 'string' || Array.isArray(args[0]))) {
-      return this.rejectByPath(...args[0]);
+      return this.rejectByPath(...args);
     }
     return new FileCollection(super.reject(...args).toArray());
   }

--- a/packages/internals/support/src/collections/file-collection.js
+++ b/packages/internals/support/src/collections/file-collection.js
@@ -16,6 +16,13 @@ class FileCollection extends EntityCollection {
     return new FileCollection(super.filter(...args).toArray());
   }
 
+  reject(...args) {
+    if (args.length === 1 && (typeof args[0] === 'string' || Array.isArray(args[0]))) {
+      return this.rejectByPath(...args[0]);
+    }
+    return new FileCollection(super.reject(...args).toArray());
+  }
+
   filterByPath(...args) {
     let paths = [].concat(...args);
     assert.array.of.string(paths, `FileCollection.filterByPath: path argument must be a string or array of strings [paths-invalid]`);

--- a/packages/internals/support/src/collections/file-collection.js
+++ b/packages/internals/support/src/collections/file-collection.js
@@ -9,6 +9,13 @@ const assert = check.assert;
 
 class FileCollection extends EntityCollection {
 
+  filter(...args) {
+    if (args.length === 1 && (typeof args[0] === 'string' || Array.isArray(args[0]))) {
+      return this.filterByPath(...args[0]);
+    }
+    return new FileCollection(super.filter(...args).toArray());
+  }
+
   filterByPath(...args) {
     let paths = [].concat(...args);
     assert.array.of.string(paths, `FileCollection.filterByPath: path argument must be a string or array of strings [paths-invalid]`);

--- a/packages/internals/support/src/collections/file-collection.test.js
+++ b/packages/internals/support/src/collections/file-collection.test.js
@@ -1,6 +1,6 @@
 /* eslint no-unused-expressions: "off" */
 
-const {expect} = require('../../../../../test/helpers');
+const {expect, sinon} = require('../../../../../test/helpers');
 const File = require('../entities/file');
 const FileCollection = require('./file-collection');
 
@@ -56,6 +56,27 @@ describe('FileCollection', function () {
       expect(() => makeCollectionFrom(new File({path: 'valid-file-object-definition/'}))).to.not.throw();
       expect(() => makeCollectionFrom([File.from({single: 'object'}), File.from({another: 'object'})])).to.throw(TypeError, '[properties-invalid]');
       expect(() => makeCollectionFrom([File.from({path: 'object'}), File.from({path: 'object'})])).to.not.throw();
+    });
+  });
+
+  describe(`.filter()`, function () {
+    it('filters by path if a single string argument is supplied', function () {
+      const collection = makeCollection();
+      const spy = sinon.spy(collection, 'filterByPath');
+      const newCollection = collection.filterByPath('dogs/*');
+      expect(spy.called).to.equal(true);
+      expect(newCollection.count()).to.equal(2);
+    });
+    it('filters by path if a single array argument is supplied', function () {
+      const collection = makeCollection();
+      const spy = sinon.spy(collection, 'filterByPath');
+      const newCollection = collection.filterByPath(['**/*', '!**/*.js']);
+      expect(spy.called).to.equal(true);
+      expect(newCollection.count()).to.equal(1);
+    });
+    it(`defers to its superclass for all other 'filter' arguments`, function () {
+      const collection = makeCollection();
+      expect(collection.filter('path', '/dogs/odie.js').count()).to.equal(1);
     });
   });
 

--- a/packages/internals/support/src/collections/file-collection.test.js
+++ b/packages/internals/support/src/collections/file-collection.test.js
@@ -80,6 +80,27 @@ describe('FileCollection', function () {
     });
   });
 
+  describe(`.reject()`, function () {
+    it('reject by path if a single string argument is supplied', function () {
+      const collection = makeCollection();
+      const spy = sinon.spy(collection, 'rejectByPath');
+      const newCollection = collection.rejectByPath('dogs/*');
+      expect(spy.called).to.equal(true);
+      expect(newCollection.count()).to.equal(2);
+    });
+    it('reject by path if a single array argument is supplied', function () {
+      const collection = makeCollection();
+      const spy = sinon.spy(collection, 'rejectByPath');
+      const newCollection = collection.rejectByPath(['**/*', '!**/*.js']);
+      expect(spy.called).to.equal(true);
+      expect(newCollection.count()).to.equal(3);
+    });
+    it(`defers to its superclass for all other 'reject' arguments`, function () {
+      const collection = makeCollection();
+      expect(collection.reject('path', '/dogs/odie.js').count()).to.equal(3);
+    });
+  });
+
   describe(`.filterByPath()`, function () {
     it('returns a collection instance', function () {
       const collection = makeCollection();

--- a/packages/internals/utils/src/utils.js
+++ b/packages/internals/utils/src/utils.js
@@ -26,6 +26,9 @@ const utils = module.exports = {
            // don't merge arrays - the target array overrides the default value
           return targetValue;
         }
+        if (_.isFunction(defaultValue) && _.isObject(targetValue)) {
+          return targetValue;
+        }
       };
     }
     const items = args.reverse().map(item => _.cloneDeep(item));

--- a/packages/internals/utils/src/utils.test.js
+++ b/packages/internals/utils/src/utils.test.js
@@ -130,6 +130,18 @@ describe('Utils', function () {
       expect(utils.defaultsDeep(target, defaults).items).to.eql(target.items);
     });
 
+    it('Does not merge functions as objects', function () {
+      let target = {
+        match: {
+          prop: 'foo'
+        }
+      };
+      let defaults = {
+        match: function doThis() {}
+      };
+      expect(utils.defaultsDeep(target, defaults).match).to.be.an('object');
+    });
+
     it('accepts a customizer as the last argument to customize the merging behaviour', function () {
       let target = {
         items: ['one', 'two']


### PR DESCRIPTION
- Overload the `FileCollection.filter()` method (and corresponding `.reject` method) to filter by path if a string or array is passed as the sole argument 
- Reworks the main fractal config structure to nest component config properties under the components key
- Change `filter` property names to `match` in config
- Use glob strings in default app config for matching component views and config files
- Use defaultsDeep for merging global config defaults with the component configuration  