### PR TITLE
Change order of <code><pre>... to <pre><code>... in markdown.js

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -11,9 +11,9 @@ renderer.code = function (code, lang, escaped) {
         code = output;
     }
     if (!lang) {
-        return `<code><pre>${code}</pre></code>`;
+        return `<pre><code>${code}</code></pre>`;
     }
-    return `<code class="${this.options.langPrefix}${escape(lang, true)}"><pre>${code}</pre></code>`;
+    return `<pre><code class="${this.options.langPrefix}${escape(lang, true)}">${code}</code></pre>`;
 };
 
 /*


### PR DESCRIPTION
`<pre><code>...dacode...</code></pre>` is the correct order for code-blocks according to W3C
https://www.w3.org/TR/2011/WD-html5-author-20110809/the-code-element.html