### PR TITLE
Don't return null for falsey context values. Fixes #400

### DIFF
--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -28,7 +28,7 @@ const resolver = module.exports = {
 
         function mapper(item, key) {
 
-            if (!item) {
+            if (item === undefined || item === null) {
                 return Promise.resolve(null);
             }
 


### PR DESCRIPTION
This PR fixes the issue where setting a context var's value to `0` or `false`, it is incorrectly converted to `null`.

foo.config.json

```json
{
  "context": {
    "foo": 0,
    "bar": false
  }
}
```

renders as:

```json
{
  "foo": null,
  "bar": null
}
```