### PR TITLE
Circular reference fix

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -1,19 +1,22 @@
-'use strict';
+"use strict";
 
-const marked = require('marked');
-const _ = require('lodash');
-const highlighter = require('./highlighter');
+const marked = require("marked");
+const _ = require("lodash");
+const highlighter = require("./highlighter");
 const renderer = new marked.Renderer();
 
-renderer.code = function (code, lang, escaped) {
-    const output = highlighter(code, lang);
-    if (output != null) {
-        code = output;
-    }
-    if (!lang) {
-        return `<code><pre>${code}</pre></code>`;
-    }
-    return `<code class="${this.options.langPrefix}${escape(lang, true)}"><pre>${code}</pre></code>`;
+renderer.code = function(code, lang, escaped) {
+  const output = highlighter(code, lang);
+  if (output != null) {
+    code = output;
+  }
+  if (!lang) {
+    return `<code><pre>${code}</pre></code>`;
+  }
+  return `<code class="${this.options.langPrefix}${escape(
+    lang,
+    true
+  )}"><pre>${code}</pre></code>`;
 };
 
 /*
@@ -21,23 +24,25 @@ renderer.code = function (code, lang, escaped) {
  */
 
 module.exports = function markdown(content, mdConfig) {
-    mdConfig = (mdConfig && _.isObject(mdConfig)) ? mdConfig : {};
-    mdConfig.renderer = renderer;
+  mdConfig = _.cloneDeep(mdConfig && _.isObject(mdConfig) ? mdConfig : {});
+  mdConfig.renderer = renderer;
 
-    return marked(_.toString(content), mdConfig);
+  return marked(_.toString(content), mdConfig);
 };
 
-module.exports.toc = function (content, maxDepth, mdConfig) {
-    maxDepth = maxDepth || 6;
-    mdConfig = (mdConfig && _.isObject(mdConfig)) ? mdConfig : {};
-    mdConfig.renderer = renderer;
+module.exports.toc = function(content, maxDepth, mdConfig) {
+  maxDepth = maxDepth || 6;
+  mdConfig = mdConfig && _.isObject(mdConfig) ? mdConfig : {};
+  mdConfig.renderer = renderer;
 
-    const tokens = marked.lexer(_.toString(content));
+  const tokens = marked.lexer(_.toString(content));
 
-    return tokens.filter(token => {
-        return token.type === 'heading' && token.depth <= maxDepth;
-    }).map(token => {
-        token.id = token.text.toLowerCase().replace(/[^\w]+/g, '-');
-        return token;
+  return tokens
+    .filter(token => {
+      return token.type === "heading" && token.depth <= maxDepth;
+    })
+    .map(token => {
+      token.id = token.text.toLowerCase().replace(/[^\w]+/g, "-");
+      return token;
     });
 };

--- a/test/core.markdown.js
+++ b/test/core.markdown.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+
+const md = require("../src/core/markdown");
+
+describe("Markdown renderer", function() {
+  it("does not directly mutate the supplied configuration object", function() {
+    const config = {};
+    const result = md("**foo**", config);
+    expect(config).eql({});
+  });
+});


### PR DESCRIPTION
This PR should address #464 as well as frctl/nunjucks#5. The circular reference issue was caused by the markdown renderer directly mutating its supplied config object, which itself (as part of the complete fractal config object) is later made available to templates as a property of the _env variable.

A basic test has been included to confirm the md config object is now cloned before mutation. If anyone is still having issues after this fix then let me know :-)