### PR TITLE
Add project title as named browser-sync instance

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -121,7 +121,7 @@ module.exports = class Server extends mix(Emitter) {
     }
 
     _startSync(resolve, reject) {
-        const syncServer = require('browser-sync').create();
+        const syncServer = require('browser-sync').create(this._app._config.project.title);
         const bsConfig = utils.defaultsDeep(this._config.syncOptions || {}, {
             logLevel: this._config.debug ? 'debug' : 'silent',
             logPrefix: 'Fractal',


### PR DESCRIPTION
This PR adds a name to the browser-sync instance that gets created equal to the name of the project. This allows other files (gulp, webpack, etc.) to access the Fractal instance directly and trigger reloads and other browser-sync API events.

Once the Fractal server is running, other files can access the instance via browser-syncs `.get` api:

```javascript
// gulpfile.js, etc.
const syncServer = require('browsersync').get('Project Name');
```

Merging this could close #501