### PR TITLE
Fixed sync crash when JS config files contain errors. (#417)

### DIFF
--- a/src/core/data.js
+++ b/src/core/data.js
@@ -62,8 +62,8 @@ module.exports = {
                 }
                 return Promise.resolve(data);
             } catch (err) {
-                Log.error(`Error loading data file ${filePath}: ${err.message}`);
-                return Promise.reject(err);
+                Log.error(`Error parsing data file ${filePath.split('/')[filePath.split('/').length - 1]}: ${err.message}`);
+                return Promise.resolve({});
             }
         } else {
             return fs.readFileAsync(filePath, 'utf8').then(contents => this.parse(contents, format)).catch(err => {


### PR DESCRIPTION
This solves the problem described in https://github.com/frctl/fractal/issues/417.

When using Fractal with JS-based config files (`*.config.js`), BrowserSync will crash and not recover if the config file has a syntax error in it. Even after fixing the syntax error, the browser will refresh, but still shows the last state of the component before the error occurred. It never reflects the new, valid state of the configuration. The only remedy is then to restart the Fractal server.

**Steps to reproduce:**

1. Create a Fractal project using the "TL;DR method" described [here](https://fractal.build/guide/getting-started.html#the-tl-dr-method).
2. Switch the `example.config.yml` file to `example.config.js`, while updating the syntax appropriately (you may need to restart the Fractal server after doing so):
```
module.exports = {
  title: "Example",
  context: {
    "text": "This is an example component!",
  }
};
```
3. Open `localhost:3000` in the browser, view the Example component, and verify that it displays as expected.
4. Make a valid change to `text`'s value within `example.config.js`, save the file, and verify that the change is automatically reflected in the browser.
5. Make an invalid change to `text`'s value within `example.config.js` (such as deleting the quotation mark at the end of the string) and save the file. Verify that an error is thrown in the command line and that the browser shows the last valid state of the component.
6. Fix the invalid change, such as adding the quotation mark back, and save the file. Also, make another change to `text`'s value.

**Expected result:** The browser should show the example component with the most recent change to `text`'s value.

**Actual result:** The browser shows `text`'s value from step 4 above and no amount of refreshing or fixing the file changes that. Only restarting the Fractal server and refreshing the page will.

**Actual result with this fix applied:** The browser will not show the component at all, but a helpful error is thrown in the command line. When the invalid change to the config file is fixed and the file is saved, the browser will refresh with the most recent changes to the file. The Fractal server never needs to be restarted.

An example of the error:

```
✘ Error parsing data file example.config.js: Invalid or unexpected token
```

This can save a huge chunk of time and confusion when developers are working with large, complex configuration files. More explanation behind how this solution was arrived upon is described in the issue linked above. The error message in this PR is slightly different than what was suggested there, but for the better.

Thank you for your work with Fractal!