### PR TITLE
Replace returned promise in dev server CLI command with async ca…

### DIFF
--- a/src/cli/commands/web.start.js
+++ b/src/cli/commands/web.start.js
@@ -44,10 +44,15 @@ module.exports = {
             } else {
                 this.console.error(err.message, err);
             }
+            done();
         });
 
-        return server.start(args.options.sync).catch(e => {
+        server.on('destroy', () => done());
+        server.on('stopped', () => done());
+
+        server.start(args.options.sync).catch(e => {
             this.console.error(e);
+            done();
         });
     },
 


### PR DESCRIPTION
Fixes #510 

It looks like the server promise is resolving when the server starts. Vorpal considers a command complete whena resolved promise is returned. I'm not 100% sure when Vorpal added this, as the project has no changelog :( That said, removing the returned promise and using the async `done` callback instead seems to do the trick.