### PR TITLE
fix: don't stop server when files are not found

### DIFF
--- a/src/cli/commands/web.start.js
+++ b/src/cli/commands/web.start.js
@@ -43,8 +43,8 @@ module.exports = {
                 this.console.warn(`404: ${err.message}`);
             } else {
                 this.console.error(err.message, err);
+                done();
             }
-            done();
         });
 
         server.on('destroy', () => done());


### PR DESCRIPTION
Notice if I have not set an favicon and running the CLI fractal start --sync. The fractal stop working in preview mode. This purposal will only stop the server if the error is not 404.