### PR TITLE
prevent 404 errors from stoppping fractal server

### DIFF
--- a/src/cli/commands/web.start.js
+++ b/src/cli/commands/web.start.js
@@ -44,7 +44,6 @@ module.exports = {
             } else {
                 this.console.error(err.message, err);
             }
-            done();
         });
 
         server.on('destroy', () => done());


### PR DESCRIPTION
as described in issue https://github.com/frctl/fractal/issues/514

current handling 404 errors as working since latest release cause the fractal dev server to stop.

**Technical scenario description**:

in _onrequest, the lack of a match creates a web error, and pushes it to the next middleware layer:
` src/web/server.js:214

            return next(new WebError(404, `No matching route found for ${req.path}`));
`

this is pushed to the _onError middleware layer, which emit an error event on the server object

` src/web/server.js:257

        this.emit('error', err, res.locals.__request);
`

this error event is caught in the dev server vorpal command, which as of latest release, calls done()

` src/cli/commands/web.start.js:41

            done();
`


which stops the dev server.
