### PR TITLE
Export Log for usage in context

### DIFF
--- a/src/fractal.js
+++ b/src/fractal.js
@@ -127,6 +127,7 @@ module.exports.Fractal = Fractal;
 module.exports.WebTheme = require('./web/theme');
 module.exports.CliTheme = require('./cli/theme');
 module.exports.Adapter = require('./core/adapter');
+module.exports.log = require('./core/log');
 module.exports.utils = require('./core/utils');
 
 module.exports.core = {


### PR DESCRIPTION
It can be pretty useful to communicate warnings and such in context:

```javascript
const { log } = require("@fractal/fractal");
log.warn("Deprecated: this context-data should not be used anymore - Use ... instead.");
```