### PR TITLE
Allow sub-components to be rendered fully

### DIFF
--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -40,7 +40,7 @@ const resolver = module.exports = {
                 return item.replace(/^\\@/, '@');
             }
 
-            if (_.isString(item) && _.startsWith(item, '@')) {
+            if (_.isString(item) && _.startsWith(item, '@@')) {
                 const entity = source.find(item.substring(1));
                 const fullRenderedComponent = source.engine().render(entity.viewPath, entity.content, entity.context, {
                     self: entity.toJSON(),

--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -40,8 +40,8 @@ const resolver = module.exports = {
                 return item.replace(/^\\@/, '@');
             }
 
-            if (_.isString(item) && _.startsWith(item, '@') && !item.includes('.')) {
-                const entity = source.find(item);
+            if (_.isString(item) && _.startsWith(item, '@')) {
+                const entity = source.find(item.substring(1));
                 const fullRenderedComponent = source.engine().render(entity.viewPath, entity.content, entity.context, {
                     self: entity.toJSON(),
                     env: {},

--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -40,6 +40,15 @@ const resolver = module.exports = {
                 return item.replace(/^\\@/, '@');
             }
 
+            if (_.isString(item) && _.startsWith(item, '@') && !item.includes('.')) {
+                const entity = source.find(item);
+                const fullRenderedComponent = source.engine().render(entity.viewPath, entity.content, entity.context, {
+                    self: entity.toJSON(),
+                    env: {},
+                });
+                return fullRenderedComponent;
+            }
+
             if (_.isString(item) && _.startsWith(item, '@')) {
                 const parts = item.split('.');
                 const handle = parts.shift();


### PR DESCRIPTION
This handles using context data '@handle' references better for template engines/styleguides which can't use partials to include other components. For example, Drupal's theming system can have other partials represented as regular twig variables.

```
label: "Menu Local Tasks"

context:
  primaryTabsTitle: "Primary Tabs"
  primary:
    - "@menulocaltask"
    - "@menulocaltask--active"
```

Currently you can only reference and render context items contained within the sub-components (e.g. `@menulocaltask.link`). Referencing as above would cause `[object Object]` to be rendered. This pull request will enable it to render the full component when no sub-context is specified with dot notation.
