### PR TITLE
allow function values in context objects

### DIFF
--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -66,6 +66,10 @@ const resolver = module.exports = {
                 return null;
             }
 
+            if (_.isFunction(item)) {
+                return item;
+            }
+
             if (_.isArray(item) || _.isObject(item)) {
                 return resolve(item);
             }


### PR DESCRIPTION
I don't believe there's an issue for this feature, but I'll do my best to explain it here.

I'm using Fractal for multiple projects with React components in a way that the components are rendered on the server and hydrated on the client. React components can have props that can be assigned functions to. For example, HTML anchors and buttons can have onClick prop.

Now, given the following config file:
```
module.exports = {
    context: {
        text: "lorem ipsum",
        onClick: function(event) {
            console.log(event);
        },
    },
};
```

Currently, the context object returned by Fractal looks like this:
```
{
    text: "lorem ipsum",
    onClick: {}
}
```

So it basically just resolves the function to an empty object.

Following this change, functions in context objects are preserved, so the returned context object looks like this.
```
{
    text: "lorem ipsum",
    onClick: function(event) {
        console.log(event);
    }
}
```