### PR TITLE
Remove end from server rendering

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -237,7 +237,7 @@ module.exports = class Server extends mix(Emitter) {
         };
 
         this._render(match.route.view, context)
-            .then(v => res.send(v).end())
+            .then(v => res.send(v))
             .catch(err => next(err));
     }
 
@@ -251,7 +251,7 @@ module.exports = class Server extends mix(Emitter) {
         }
 
         this._render(this._theme.errorView(), { error: err })
-            .then(v => res.send(v).end())
+            .then(v => res.send(v))
             .catch(err => next(err));
 
         this.emit('error', err, res.locals.__request);


### PR DESCRIPTION
Removes `.end()` since `.send()` already handles this:

> "Use to quickly end the response without any data. If you need to respond with data, instead use methods such as res.send() and res.json()." - https://expressjs.com/en/4x/api.html#res.end 

Will hopefully address some occasional failed responses. See #545 for context.