### PR TITLE
add exclude config option to components

### DIFF
--- a/src/api/components/source.js
+++ b/src/api/components/source.js
@@ -341,12 +341,18 @@ module.exports = class ComponentSource extends EntitySource {
     }
 
     isView(file) {
-        return anymatch([
+        const matchers = [
             `**/*${this.get('ext')}`,
             `!**/*${this.get('splitter')}*${this.get('ext')}`,
             `!**/*.${this.get('files.config')}.${this.get('ext')}`,
             `!**/${this.get('files.config')}.{js,json,yaml,yml}`
-        ], this._getPath(file));
+        ];
+
+        if (this.get('exclude')) {
+            matchers.push(`!${this.get('exclude')}`);
+        }
+
+        return anymatch(matchers, this._getPath(file));
     }
 
     isVarView(file) {


### PR DESCRIPTION
This PR will resolve #556.

Following this change, we will allow users to exclude some directories from Fractal structure like so:
```js
fractal.components.set('exclude', '**/node_modules/**');
```