### PR TITLE
Allow sub-components to be rendered fully

### DIFF
--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -40,6 +40,15 @@ const resolver = module.exports = {
                 return item.replace(/^\\@/, '@');
             }
 
+	        if (_.isString(item) && _.startsWith(item, '@@')) {
+                const entity = source.find(item.substring(1));
+                const fullRenderedComponent = source.engine().render(entity.viewPath, entity.content, entity.context, {
+                    self: entity.toJSON(),
+                    env: {},
+                });
+                return fullRenderedComponent;
+            }
+
             if (_.isString(item) && _.startsWith(item, '@')) {
                 const parts = item.split('.');
                 const handle = parts.shift();


### PR DESCRIPTION
Currently you can only reference and render context items contained within sub-components (e.g. `@menulocaltask.link`). Referencing `@menulocaltask` causes `[object Object]` to be rendered. This pull request adds the ability to reference `@@menulocaltask`, which will enable it to render the full component when no sub-context is specified with dot notation.

This is useful for template engines/styleguides which can't use partials to include other components. For example, Drupal's theming system can have other partials represented as regular twig variables.

Example:

```
label: "Menu Local Tasks"

context:
  primaryTabsTitle: "Primary Tabs"
  primary:
    - "@@menulocaltask"
    - "@@menulocaltask--active"
```

