### PR TITLE
resolve date in config to JSON string

### DIFF
--- a/src/core/resolver.js
+++ b/src/core/resolver.js
@@ -66,6 +66,10 @@ const resolver = module.exports = {
                 return null;
             }
 
+            if (_.isDate(item)) {
+                return item.toJSON();
+            }
+
             if (_.isArray(item) || _.isObject(item)) {
                 return resolve(item);
             }


### PR DESCRIPTION
Resolves #455 

Now, when using:
```yaml
context:
  date: 2020-01-01
```
it will be resolved to `2020-01-01T00:00:00.000Z`.

We could also resolve it to string (`Wed Jan 01 2020 02:00:00 GMT+0200 (GMT+02:00)`), but I think ISO timestamp is more correct in this case. I believe everything else in context is resolved to JSON as well in the end.