### PR TITLE
append extension to relative URLs too

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -132,11 +132,15 @@ module.exports = {
     },
 
     relUrlPath(toPath, fromPath, opts) {
-        if (toPath.startsWith('http') || toPath.startsWith('.')) {
+        if (toPath.startsWith('http')) {
             return toPath;
         }
 
         const ext = opts.ext || '';
+
+        if (toPath.startsWith('.')) {
+            return ext === '' ? toPath : toPath + ext;
+        }
 
         fromPath = getStaticPagePath(fromPath).replace(/\\/g, '/');
         toPath = ('/' + _.trim(Path.extname(toPath) ? toPath : getStaticPagePath(toPath), '/')).replace(/\\/g, '/');


### PR DESCRIPTION
Resolves #522.

Quoting my comment from the issue:

> In order to get the correct URLs, you should use the path helper that's been provided by most official adapters. For example, with the default handlebars adapter, [Change Log]({{path './change_log'}}) should do the trick.
>
> However, the core utility function that the path helpers in adapters use, returns early for relative paths. This is a bug, since even relative paths should be appended with the proper file extension.

Basically currently there's a difference how `{{path 'change_log' }}` and `{{path './change_log' }}` work, even though they really point to the same relative path.