### PR TITLE
add hljs class to code elements

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -11,9 +11,9 @@ renderer.code = function(code, lang, escaped) {
     code = output;
   }
   if (!lang) {
-    return `<pre><code>${code}</code></pre>`;
+    return `<pre><code class="hljs">${code}</code></pre>`;
   }
-  return `<pre><code class="${this.options.langPrefix}${escape(
+  return `<pre><code class="hljs ${this.options.langPrefix}${escape(
     lang,
     true
   )}">${code}</code></pre>`;


### PR DESCRIPTION
This will partially resolve #484.

Without the hljs class, only the contents of the code blocks are styled according to the highlight.js theme. If the user tries to customize the highlight.js theme (for example, use a dark theme), the background is provided by mandelbrot and might not match the hljs theme background.

This needs frctl/mandelbrot#105 as well.