### PR TITLE
chore: update istextorbinary to get newer extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,9 +1480,9 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
     "binaryextensions": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-      "integrity": "sha1-MgmlHKSkrVQaO409am1bg6JIWTU="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.2.0.tgz",
+      "integrity": "sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw=="
     },
     "blob": {
       "version": "0.0.5",
@@ -3370,11 +3370,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha1-NmLLWSNHwxaOuOSYoP9zJx1n9Qs="
-    },
     "editorconfig": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
@@ -5166,13 +5161,12 @@
       }
     },
     "istextorbinary": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
-      "integrity": "sha1-pSMaCO9t0ismjQiVCEz41Ytb7FM=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-3.3.0.tgz",
+      "integrity": "sha512-Tvq1W6NAcZeJ8op+Hq7tdZ434rqnMx4CCZ7H0ff83uEloDvVbqAwaMTZcafKGJT0VHkYzuXUiCY4hlXQg6WfoQ==",
       "requires": {
-        "binaryextensions": "2",
-        "editions": "^1.3.3",
-        "textextensions": "2"
+        "binaryextensions": "^2.2.0",
+        "textextensions": "^3.2.0"
       }
     },
     "js-beautify": {
@@ -7771,9 +7765,9 @@
       }
     },
     "textextensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-      "integrity": "sha1-OKxnYVEoW2WGVFgZh6DOGkSQ0oY="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-3.3.0.tgz",
+      "integrity": "sha512-mk82dS8eRABNbeVJrEiN5/UMSCliINAuz8mkUwH4SwslkNP//gbEzlWNS5au0z5Dpx40SQxzqZevZkn+WYJ9Dw=="
     },
     "tfunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "handlebars": "^4.0.13",
     "highlight.js": "^9.5.0",
     "inquirer": "^1.1.2",
-    "istextorbinary": "^2.1.0",
+    "istextorbinary": "^3.3.0",
     "js-yaml": "^3.13.1",
     "liftoff": "^2.3.0",
     "lodash": "^4.17.11",

--- a/src/core/fs.js
+++ b/src/core/fs.js
@@ -6,11 +6,9 @@ const co = require('co');
 const _ = require('lodash');
 const fs = Promise.promisifyAll(require('fs'));
 const readFile = Promise.promisify(fs.readFile);
-const isBinary = Promise.promisify(require('istextorbinary').isBinary);
+const isBinary = require('istextorbinary').isBinaryPromise;
 const utils = require('./utils');
 const glob = require('globby');
-
-const notBinary = ['.nunj', '.nunjucks', '.hbs', '.handlebars', '.jsx', '.twig']; // TODO: handle this in a scalable, extendable way
 
 module.exports = {
 
@@ -142,8 +140,5 @@ function dirscribe(root, opts) {
 }
 
 function checkIsBinary(file) {
-    if (_.includes(notBinary, file.ext)) {
-        return Promise.resolve(false);
-    }
     return isBinary(file.path, null);
 }


### PR DESCRIPTION
Fixes #588

It's a major bump but according to [their changelog](https://github.com/bevry/istextorbinary/blob/master/HISTORY.md#v300-2019-november-18), it's because of the drop of Node versions below 8, which we already doesn't support anymore.