### PR TITLE
Fix typos

### DIFF
--- a/packages/fractal/bin/fractal
+++ b/packages/fractal/bin/fractal
@@ -76,7 +76,7 @@ FractalCli.launch(config, function(env){
         }
 
         if (! app || ! app.__fractal) {
-            // looks like the configuration file is not correctly module.export'ing a fractal intance
+            // looks like the configuration file is not correctly module.export'ing a fractal instance
             console.log(`${chalk.red('Configuration error')}: The CLI configuration file is not exporting an instance of Fractal.`);
             return;
         }

--- a/packages/mandelbrot/README.md
+++ b/packages/mandelbrot/README.md
@@ -9,7 +9,7 @@ In order to get a locale aware date for the 'last updated' text, install the
 
 ## Customize theme labels
 
-Some theme-specific labels can be overriden via config options:
+Some theme-specific labels can be overridden via config options:
 
 ```
 const theme = require('@frctl/mandelbrot')({


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `packages/fractal/bin/fractal`
- 1 typo in `packages/mandelbrot/README.md`



Bye! :robot: