### PR TITLE
refactor: change bin file to js & lint/format

### DIFF
--- a/packages/fractal/package.json
+++ b/packages/fractal/package.json
@@ -54,7 +54,7 @@
     "sinon": "^9.0.1"
   },
   "bin": {
-    "fractal": "./bin/fractal"
+    "fractal": "./bin/fractal.js"
   },
   "engines": {
     "node": ">= 10.0.0"


### PR DESCRIPTION
Since the bin file did not have a js extension, it was not linted/formatted in #612. This also means that it currently bypasses all import lint rules that are rather important.

Looking at the JS ecosystem, it seems fairly common that the bin file is a JS file, so I'm fairly comfortable changing this.