### PR TITLE
feat: allow resizing pen preview height on narrow screens

### DIFF
--- a/packages/mandelbrot/assets/scss/components/_pen.scss
+++ b/packages/mandelbrot/assets/scss/components/_pen.scss
@@ -29,7 +29,6 @@
 
     @include mq($until: nav-collapse) {
         margin: 0;
-        border-bottom: 1px solid $color-frame-border;
         padding: 0.75rem;
 
         .Status .Status-label {
@@ -75,10 +74,7 @@
     margin: 0 $handle-size;
 
     @include mq($until: nav-collapse) {
-        flex: 1 1 auto;
-        height: auto !important;
-        max-height: 100%;
-        margin: 0;
+        max-height: calc(100% - 4.75rem);
     }
 }
 
@@ -94,6 +90,7 @@
 
     @include mq($until: nav-collapse) {
         display: none;
+        height: $handle-size + 1rem;
     }
 }
 
@@ -110,8 +107,4 @@
     margin: $handle-size;
     margin-top: 0;
     border: 1px solid $color-frame-border;
-
-    @include mq($until: nav-collapse) {
-        display: none;
-    }
 }

--- a/packages/mandelbrot/assets/scss/components/_preview.scss
+++ b/packages/mandelbrot/assets/scss/components/_preview.scss
@@ -1,5 +1,7 @@
 .Preview {
     position: relative;
+    background-color: $color-background-offset;
+    border: 1px solid $color-frame-border;
 
     &.is-disabled {
         .Preview-overlay {
@@ -13,11 +15,6 @@
         * {
             cursor: grabbing !important;
         }
-    }
-
-    @include mq(nav-collapse) {
-        background-color: $color-background-offset;
-        border: 1px solid $color-frame-border;
     }
 }
 
@@ -33,6 +30,10 @@
     min-width: 200px;
     max-width: calc(100% + #{$handle-size});
     background-color: transparent;
+
+    @include mq($until: nav-collapse) {
+        width: 100% !important;
+    }
 }
 
 .Preview-resizer {


### PR DESCRIPTION
Resolves #610.

I opted to use the same functionality we have on larger screens - pen preview resizing. I tested it and it seemed to work fine on touch screens as well. I made the handle a bit larger, though, to make it easier to target with fingers. If users want the preview to take up 100% height (like it has been so far), now they need to drag the handle to the bottom of their screen.