### PR TITLE
feat: allow customizing skin with hex codes

### DIFF
--- a/packages/mandelbrot/assets/scss/components/_asset-list.scss
+++ b/packages/mandelbrot/assets/scss/components/_asset-list.scss
@@ -13,7 +13,10 @@
     color: rgba($color-text, 0.5);
 
     strong {
+        --color: rgb(var(--skin-links));
+
         color: $color-link;
+        color: var(--color, $color-link);
         font-weight: normal;
     }
 }

--- a/packages/mandelbrot/assets/scss/components/_browser.scss
+++ b/packages/mandelbrot/assets/scss/components/_browser.scss
@@ -52,7 +52,10 @@
 
     &.is-active {
         a {
+            --border-color: rgb(var(--skin-links));
+
             border-bottom-color: $color-link;
+            border-bottom-color: var(--border-color, $color-link);
             font-weight: bolder;
         }
     }

--- a/packages/mandelbrot/assets/scss/components/_file-browser.scss
+++ b/packages/mandelbrot/assets/scss/components/_file-browser.scss
@@ -35,8 +35,11 @@
     border-color: $color-frame-border;
 
     .select2-container--focus & {
+        --border-color: rgb(var(--skin-links));
+
         outline: none;
         border-color: $color-link;
+        border-color: var(--border-color, $color-link);
     }
 }
 
@@ -51,8 +54,13 @@
 }
 
 .select2-results__option--highlighted[aria-selected] {
+    --background-color: rgb(var(--skin-accent));
+    --color: rgb(var(--skin-complement));
+
     background-color: $color-header-background !important;
+    background-color: var(--background-color, $color-header-background) !important;
     color: $color-header-content !important;
+    color: var(--color, $color-header-content) !important;
 }
 
 .FileBrowser-item {

--- a/packages/mandelbrot/assets/scss/components/_header.scss
+++ b/packages/mandelbrot/assets/scss/components/_header.scss
@@ -1,12 +1,17 @@
 .Header {
+    --background-color: rgb(var(--skin-accent));
+    --color: rgb(var(--skin-complement));
+
     display: flex;
     align-items: center;
     position: relative;
     z-index: 10;
     background-color: $color-header-background;
+    background-color: var(--background-color, $color-header-background);
     box-shadow: inset 0 -1px 0 0 rgba(black, 0.25), 0 2px 0 rgba(black, 0.1);
     text-overflow: ellipsis;
     color: $color-header-content;
+    color: var(--color, $color-header-content);
 }
 
 .Header-title {
@@ -21,7 +26,9 @@
 }
 
 .Header-button {
+    --border-color: rgba(var(--skin-complement), 0.25);
     @include border-inline(end, 1px solid rgba($color-header-content, 0.25));
+    @include border-inline(end, 1px solid var(--border-color, rgba($color-header-content, 0.25)));
 
     display: block;
     flex-shrink: 0;
@@ -32,18 +39,23 @@
     color: inherit;
 
     &:hover {
+        --background-color: rgba(var(--skin-complement), 0.05);
+
         background-color: rgba($color-header-content, 0.05);
+        background-color: var(--background-color, rgba($color-header-content, 0.05));
     }
 
     &:active {
+        --background-color: rgba(var(--skin-complement), 0.1);
+
         background-color: rgba($color-header-content, 0.1);
+        background-color: var(--background-color, rgba($color-header-content, 0.1));
     }
 }
 
 .Header-navToggleIcon {
     display: none;
     margin: 0 auto;
-    fill: $color-header-content;
 }
 
 .Frame {

--- a/packages/mandelbrot/assets/scss/components/_pen.scss
+++ b/packages/mandelbrot/assets/scss/components/_pen.scss
@@ -59,7 +59,10 @@
     @include link-default($color-heading, none);
 
     svg {
+        --fill: rgb(var(--skin-links));
+
         fill: $color-link;
+        fill: var(--fill, $color-link);
         opacity: 0.75;
     }
 

--- a/packages/mandelbrot/assets/scss/core/_foundation.scss
+++ b/packages/mandelbrot/assets/scss/core/_foundation.scss
@@ -5,7 +5,10 @@
 }
 
 ::selection {
+    --background-color: rgba(var(--skin-links), 0.2);
+
     background-color: rgba($color-link, 0.2);
+    background-color: var(--background-color, rgba($color-link, 0.2));
 }
 
 html {
@@ -70,15 +73,22 @@ ul {
 }
 
 a {
-    color: $color-link;
+    --color: rgba(var(--skin-links), 0.9);
+
+    color: rgba($color-link, 0.9);
+    color: var(--color, rgba($color-link, 0.9));
     transition: all 0.15s ease-out;
 
     &:active {
         color: $color-link;
+        color: var(--color, rgba($color-link, 0.9));
     }
 
     &:hover {
-        color: darken($color-link, 15%);
+        --color: rgb(var(--skin-links));
+
+        color: $color-link;
+        color: var(--color, $color-link);
     }
 }
 
@@ -172,5 +182,8 @@ h6 {
 }
 
 mark {
+    --background-color: rgba(var(--skin-links), 0.3);
+
     background-color: rgba($color-link, 0.3);
+    background-color: var(--background-color, rgba($color-link, 0.3));
 }

--- a/packages/mandelbrot/src/filters.js
+++ b/packages/mandelbrot/src/filters.js
@@ -82,4 +82,25 @@ module.exports = function (theme, env, app) {
             }
         });
     });
+
+    env.engine.addFilter('hexToRgb', function (h) {
+        let r = 0,
+            g = 0,
+            b = 0;
+
+        // 3 digits
+        if (h.length == 4) {
+            r = '0x' + h[1] + h[1];
+            g = '0x' + h[2] + h[2];
+            b = '0x' + h[3] + h[3];
+
+            // 6 digits
+        } else if (h.length == 7) {
+            r = '0x' + h[1] + h[2];
+            g = '0x' + h[3] + h[4];
+            b = '0x' + h[5] + h[6];
+        }
+
+        return `${parseInt(r, 16)}, ${parseInt(g, 16)}, ${parseInt(b, 16)}`;
+    });
 };

--- a/packages/mandelbrot/src/theme.js
+++ b/packages/mandelbrot/src/theme.js
@@ -32,12 +32,21 @@ module.exports = function (options) {
             },
         },
     });
+    config.skin =
+        typeof config.skin === 'string'
+            ? {
+                  name: config.skin,
+              }
+            : {
+                  name: 'default',
+                  ...config.skin,
+              };
 
     const uiStyles = []
         .concat(config.styles)
         .concat(config.stylesheet)
         .filter((url) => url)
-        .map((url) => (url === 'default' ? `/${config.static.mount}/css/${config.skin}.css` : url));
+        .map((url) => (url === 'default' ? `/${config.static.mount}/css/${config.skin.name}.css` : url));
     const highlightStyles = []
         .concat(config.highlightStyles)
         .filter((url) => url)

--- a/packages/mandelbrot/views/partials/stylesheets.nunj
+++ b/packages/mandelbrot/views/partials/stylesheets.nunj
@@ -1,3 +1,16 @@
+<style>
+    :root {
+        {% if frctl.theme.get('skin.accent') %}
+        --skin-accent: {{ frctl.theme.get('skin.accent')|hexToRgb }};
+        {% endif %}
+        {% if frctl.theme.get('skin.complement') %}
+        --skin-complement: {{ frctl.theme.get('skin.complement')|hexToRgb }};
+        {% endif %}
+        {% if frctl.theme.get('skin.links') %}
+        --skin-links: {{ frctl.theme.get('skin.links')|hexToRgb }};
+        {% endif %}
+    }
+</style>
 {% for stylesheet in frctl.theme.get('styles') %}
 <link rel="stylesheet" href="{{ path(stylesheet) }}?cachebust={{ frctl.theme.get('version') }}" type="text/css">
 {% endfor %}


### PR DESCRIPTION
Resolves #601.

Following this change, users will be able to customize Mandelbrot's sking with hex codes.

Previously we allowed specifying only the skin name:
```js
const mandelbrot = require('@frctl/mandelbrot')({
    skin: 'fuchsia',
});
```

Now we will allow specifying an object with skin name and hex codes:
```js
const mandelbrot = require('@frctl/mandelbrot')({
    skin: {
        name: 'default',
        accent: '#f2d',
        complement: '#402',
        links: '#a06',
    },
});
```
We'll allow three colors - following the same naming convention in our skins definition. If the user's browser does not support CSS variables, it'll use the fallback color scheme (which defaults to default).

This will need documenting, once merged.

### Technical gibberish
- I'm converting the user-specified hex codes into RGB for the CSS variables. This is so we could use rgba in our styles, where needed. [See more](https://stackoverflow.com/questions/29591465/use-css-variables-with-rgba-for-gradient-transparency)
- All of the CSS variables are defined as rgb/rgba in a local variables. This is because Sass otherwise interprets the rgb/rgba as its own functions and it won't work. [See more](https://github.com/sass/node-sass/issues/2251)