### PR TITLE
feat: allow overriding/extending highlighter

### DIFF
--- a/packages/fractal/config.js
+++ b/packages/fractal/config.js
@@ -128,5 +128,6 @@ module.exports = {
         assets: {
             mount: 'assets',
         },
+        highlighter: require('@frctl/core').highlighter,
     },
 };

--- a/packages/web/src/engine/filters/highlight.js
+++ b/packages/web/src/engine/filters/highlight.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const highlight = require('@frctl/core').highlighter;
-
-module.exports = function () {
+module.exports = function (app) {
     return {
         name: 'highlight',
-        filter: (str, lang) => highlight(str, lang),
+        filter: (str, lang) => app.get('web.highlighter')(str, lang),
     };
 };


### PR DESCRIPTION
Resolves #582.

For example, adding svelte language support:
```js
const hljs = require('highlight.js');
const hljs_svelte = require('highlightjs-svelte');
const _ = require('lodash');

hljs_svelte(hljs);

fractal.web.set('highlighter', function (content, lang) {
    content = _.toString(content || '');
    lang = lang ? lang.toLowerCase() : lang;
    try {
        return lang ? hljs.highlight(lang, content).value : hljs.highlightAuto(content).value;
    } catch (e) {
        return hljs.highlightAuto(content).value;
    }
});
```
I thought about just allowing passing in an extended HighlightJS, but this would be more dynamic - it would allow to use some other highlighting lib if necessary.

Needs documenting after merge.