### PR TITLE
fix: properly load notes from readme files for components variants

### DIFF
--- a/examples/handlebars/components/notes/notes.spec.js
+++ b/examples/handlebars/components/notes/notes.spec.js
@@ -20,9 +20,8 @@ describe('tree', () => {
         expect(cmp.notes).toBe('Component Notes\n');
     });
 
-    // FIXME: This behavior seems broken
-    // it('loads notes from readme file for variants', async () => {
-    //     const cmp = await fractal.components.find('@notes-files--alt');
-    //     expect(cmp.notes).toBe('Component Notes for variant\n');
-    // });
+    it('loads notes from readme file for variants', async () => {
+        const cmp = await fractal.components.find('@notes-files--alt');
+        expect(cmp.notes).toBe('Component Notes for variant\n');
+    });
 });

--- a/packages/fractal/src/api/variants/collection.js
+++ b/packages/fractal/src/api/variants/collection.js
@@ -95,7 +95,8 @@ module.exports = class VariantCollection extends EntityCollection {
         function findReadme(name) {
             const readmeName = `${opts.viewName}${source.get('splitter')}${name}.${source.get(
                 'files.notes'
-            )}`.toLowerCase();
+            )}.md`.toLowerCase();
+
             return _.find(readmes, (f) => f.name.toLowerCase() === readmeName);
         }
 


### PR DESCRIPTION
⚠️ Branched from `examples`/#615, should be merged within or after.

Fixes #629