### PR TITLE
feat: filter excluded files/directories in the file system parsing stage

### DIFF
--- a/packages/core/src/mixins/source.js
+++ b/packages/core/src/mixins/source.js
@@ -202,24 +202,18 @@ module.exports = mixin(
                 const exclude = this.get('exclude');
                 const matchers = [];
 
-                function addMatcher(matcher) {
-                    if (_.isString(matcher)) {
-                        matchers.push(`${matcher}`);
-                    }
-                }
-
                 if (_.isArray(exclude)) {
                     for (const excludeItem of exclude) {
-                        addMatcher(`${excludeItem}`);
+                        matchers.push(`${excludeItem}`);
                     }
                 } else {
-                    addMatcher(`${exclude}`);
+                    matchers.push(`${exclude}`);
                 }
 
                 return fs.describe(
                     this.fullPath,
                     this.relPath,
-                    exclude ? (filePath) => !anymatch(matchers, filePath) : undefined,
+                    matchers.length ? (filePath) => !anymatch(matchers, filePath) : undefined,
                     this.get('ext')
                 );
             }

--- a/packages/core/src/mixins/source.js
+++ b/packages/core/src/mixins/source.js
@@ -199,7 +199,29 @@ module.exports = mixin(
             }
 
             _getTree() {
-                return fs.describe(this.fullPath, this.relPath, undefined, this.get('ext'));
+                const exclude = this.get('exclude');
+                const matchers = [];
+
+                function addMatcher(matcher) {
+                    if (_.isString(matcher)) {
+                        matchers.push(`${matcher}`);
+                    }
+                }
+
+                if (_.isArray(exclude)) {
+                    for (const excludeItem of exclude) {
+                        addMatcher(`${excludeItem}`);
+                    }
+                } else {
+                    addMatcher(`${exclude}`);
+                }
+
+                return fs.describe(
+                    this.fullPath,
+                    this.relPath,
+                    exclude ? (filePath) => !anymatch(matchers, filePath) : undefined,
+                    this.get('ext')
+                );
             }
 
             _parse() {

--- a/packages/core/src/mixins/source.js
+++ b/packages/core/src/mixins/source.js
@@ -200,20 +200,11 @@ module.exports = mixin(
 
             _getTree() {
                 const exclude = this.get('exclude');
-                const matchers = [];
-
-                if (_.isArray(exclude)) {
-                    for (const excludeItem of exclude) {
-                        matchers.push(`${excludeItem}`);
-                    }
-                } else {
-                    matchers.push(`${exclude}`);
-                }
 
                 return fs.describe(
                     this.fullPath,
                     this.relPath,
-                    matchers.length ? (filePath) => !anymatch(matchers, filePath) : undefined,
+                    exclude ? (filePath) => !anymatch(exclude, filePath) : undefined,
                     this.get('ext')
                 );
             }

--- a/packages/fractal/src/api/components/source.js
+++ b/packages/fractal/src/api/components/source.js
@@ -352,31 +352,15 @@ module.exports = class ComponentSource extends EntitySource {
     }
 
     isView(file) {
-        const matchers = [
-            `**/*${this.get('ext')}`,
-            `!**/*${this.get('splitter')}*${this.get('ext')}`,
-            `!**/*.${this.get('files.config')}.${this.get('ext')}`,
-            `!**/${this.get('files.config')}.{js,json,yaml,yml}`,
-        ];
-        const exclude = this.get('exclude');
-
-        function addMatcher(matcher) {
-            if (_.isString(matcher)) {
-                matchers.push(`${matcher}`);
-            }
-        }
-
-        if (exclude) {
-            if (_.isArray(exclude)) {
-                for (const excludeItem of exclude) {
-                    addMatcher(`!${excludeItem}`);
-                }
-            } else {
-                addMatcher(`!${exclude}`);
-            }
-        }
-
-        return anymatch(matchers, this._getPath(file));
+        return anymatch(
+            [
+                `**/*${this.get('ext')}`,
+                `!**/*${this.get('splitter')}*${this.get('ext')}`,
+                `!**/*.${this.get('files.config')}.${this.get('ext')}`,
+                `!**/${this.get('files.config')}.{js,json,yaml,yml}`,
+            ],
+            this._getPath(file)
+        );
     }
 
     isVarView(file) {


### PR DESCRIPTION
Fixes #660. 

This will increase file system parsing performance when there are huge amounts of excluded files and/or directories. For example. in my project (which is a monorepo where there are a lot of excluded node_modules dirs), I counted how many times the [build function](https://github.com/frctl/fractal/blob/main/packages/core/src/fs.js#L52) was called. Before this change, it was called 30412 times. After this change, only 2269 times. Time-wise it's something like 36s down to 6s. So it's pretty obvious how much perf this gives us, since Fractal parses the entire tree on every file change.