### PR TITLE
ci: automate release process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text eol=lf
+*.png binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,8 @@ jobs:
     - run: npx lerna version --conventional-commits --create-release github
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # - run: npx lerna publish
+    - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - run: npx lerna publish from-git --yes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: 'https://registry.npmjs.org'
+    - run: git config user.name github-actions
+    - run: git config user.email github-actions@github.com
+    - run: npm ci
+    - run: npm run bootstrap
+    - run: npx lerna version --conventional-commits --create-release github
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # - run: npx lerna publish
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,9 @@ jobs:
     - run: git config user.email github-actions@github.com
     - run: npm ci
     - run: npm run bootstrap
-    - run: npx lerna version --conventional-commits --create-release github
+    - run: npx lerna version --conventional-commits --create-release github --yes
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - run: npx lerna publish from-git --yes
-
+    - run: npx lerna publish from-git --yes --no-verify-access
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "validate": "npm run eslint && npm run stylelint",
     "format": "npm run eslint -- --fix",
     "test": "npm run validate && lerna run test",
-    "release": "lerna version --conventional-commits --no-push",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,5 +39,8 @@
   "scripts": {
     "test": "mocha --require test/support/env --reporter spec",
     "coverage": "nyc --reporter=lcov --reporter=text  npm run test"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/handlebars/package.json
+++ b/packages/handlebars/package.json
@@ -23,5 +23,8 @@
   },
   "peerDependencies": {
     "@frctl/fractal": "^1.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/mandelbrot/package.json
+++ b/packages/mandelbrot/package.json
@@ -54,5 +54,8 @@
     "@frctl/web": "^0.0.0",
     "js-beautify": "^1.6.2",
     "lodash": "^4.17.11"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/nunjucks/package.json
+++ b/packages/nunjucks/package.json
@@ -22,5 +22,8 @@
     "bluebird": "^3.5.2",
     "lodash": "^4.17.11",
     "nunjucks": "^3.2.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/twig/package.json
+++ b/packages/twig/package.json
@@ -21,5 +21,8 @@
   },
   "peerDependencies": {
     "@frctl/fractal": "^1.1.0-beta.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,5 +29,8 @@
     "require-all": "^2.0.0",
     "throat": "^3.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
So this will:
- create a release through lerna with conventional commits (e.g. automatic versioning)
- push that release to the repository
- create a release on GitHub (yay!)
- publish the new versions/packages on npm

The workflow needs to be manually triggered on the repo.

I've validated that this workflow works [here](https://github.com/mihkeleidast/github-actions-lerna-publish-test), so fingers crossed this does not need some special config for a different repository.