### PR TITLE
ci: make github actions use personal access token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
+        token: ${{ secrets.ADMIN_TOKEN }}
     - uses: actions/setup-node@v1
       with:
         node-version: 12


### PR DESCRIPTION
This should resolve the issues I had this morning with the default token not being allowed to push to a protected branch.