### PR TITLE
fix(Mandelbrot): Properly initialize assets tab file select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4380,12 +4380,6 @@
         }
       }
     },
-    "almond": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/almond/-/almond-0.3.3.tgz",
-      "integrity": "sha1-oOfJWsdiTWQXtElLHmi/9pMWiiA=",
-      "dev": true
-    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -16271,12 +16265,6 @@
       "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==",
       "dev": true
     },
-    "jquery-mousewheel": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",
-      "integrity": "sha1-BvAzXxbjU6aV5yBr9QUDy1I6buU=",
-      "dev": true
-    },
     "jquery-pjax": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jquery-pjax/-/jquery-pjax-2.0.1.tgz",
@@ -21695,14 +21683,10 @@
       }
     },
     "select2": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.3.tgz",
-      "integrity": "sha1-IHcz/pHqy5yxoT8SRjQB9HJEng8=",
-      "dev": true,
-      "requires": {
-        "almond": "~0.3.1",
-        "jquery-mousewheel": "~3.1.13"
-      }
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
+      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "nyc": "^15.0.1",
     "prettier": "^2.0.5",
     "sass-mq": "^3.2.6",
-    "select2": "^4.0.3",
+    "select2": "^4.0.13",
     "sinon": "^9.0.1",
     "stylelint": "^13.3.3",
     "stylelint-config-prettier": "^8.0.1",

--- a/packages/mandelbrot/assets/js/components/browser.js
+++ b/packages/mandelbrot/assets/js/components/browser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const $ = global.jQuery;
-require('select2');
+require('select2')();
 const storage = require('../storage');
 
 class Browser {

--- a/packages/mandelbrot/package.json
+++ b/packages/mandelbrot/package.json
@@ -45,7 +45,7 @@
     "normalize.css": "^4.1.1",
     "prettier": "^2.0.5",
     "sass-mq": "^3.2.6",
-    "select2": "^4.0.3",
+    "select2": "^4.0.13",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "watchify": "^3.7.0"


### PR DESCRIPTION
Closes #668

Select2 changed the way it detects modules starting 4.0.4, see [this comments thread](https://github.com/select2/select2/commit/45a877345482956021161203ac789c25f40a7d5e). Apparently it’s still not fixed in the latest version 4.0.13 so let’s go for the workaround.

FTR the regression on our side was introduced since [this commit](https://github.com/frctl/fractal/commit/e2fe7699dc47b1177894fc85c57f2e6d16fdf71f#diff-b3c812e431a045641b9e7129190c5ff4b31bab06bda461695572ad1e079b3f6eL55).