### PR TITLE
feat: allow custom information properties

### DIFF
--- a/packages/mandelbrot/assets/scss/components/_tree.scss
+++ b/packages/mandelbrot/assets/scss/components/_tree.scss
@@ -142,3 +142,8 @@
     padding-top: 0.375rem;
     opacity: 0.7;
 }
+
+.Tree-asideTerm,
+.Tree-asideDescription {
+    display: inline;
+}

--- a/packages/mandelbrot/src/theme.js
+++ b/packages/mandelbrot/src/theme.js
@@ -6,6 +6,53 @@ const Theme = require('@frctl/web').Theme;
 const packageJSON = require('../package.json');
 
 module.exports = function (options) {
+    const labels = _.defaultsDeep(_.clone((options || {}).labels || {}), {
+        info: 'Information',
+        builtOn: 'Built on',
+        search: {
+            label: 'Search',
+            placeholder: 'Search…',
+            clear: 'Clear search',
+        },
+        tree: {
+            collapse: 'Collapse tree',
+        },
+        components: {
+            handle: 'Handle',
+            tags: 'Tags',
+            variants: 'Variants',
+            context: {
+                empty: 'No context defined.',
+            },
+            notes: {
+                empty: 'No notes defined.',
+            },
+            preview: {
+                label: 'Preview',
+                withLayout: 'With layout',
+                componentOnly: 'Component only',
+            },
+            path: 'Filesystem Path',
+            references: 'References',
+            referenced: 'Referenced by',
+            resources: {
+                file: 'File',
+                content: 'Content',
+                previewUnavailable: 'Previews are currently not available for this file type.',
+                url: 'URL',
+                path: 'Filesystem Path',
+                size: 'Size',
+            },
+        },
+        panels: {
+            html: 'HTML',
+            view: 'View',
+            context: 'Context',
+            resources: 'Resources',
+            info: 'Info',
+            notes: 'Notes',
+        },
+    });
     const config = _.defaultsDeep(_.clone(options || {}), {
         skin: 'default',
         rtl: false,
@@ -19,53 +66,7 @@ module.exports = function (options) {
         },
         version: packageJSON.version,
         favicon: null,
-        labels: {
-            info: 'Information',
-            builtOn: 'Built on',
-            search: {
-                label: 'Search',
-                placeholder: 'Search…',
-                clear: 'Clear search',
-            },
-            tree: {
-                collapse: 'Collapse tree',
-            },
-            components: {
-                handle: 'Handle',
-                tags: 'Tags',
-                variants: 'Variants',
-                context: {
-                    empty: 'No context defined.',
-                },
-                notes: {
-                    empty: 'No notes defined.',
-                },
-                preview: {
-                    label: 'Preview',
-                    withLayout: 'With layout',
-                    componentOnly: 'Component only',
-                },
-                path: 'Filesystem Path',
-                references: 'References',
-                referenced: 'Referenced by',
-                resources: {
-                    file: 'File',
-                    content: 'Content',
-                    previewUnavailable: 'Previews are currently not available for this file type.',
-                    url: 'URL',
-                    path: 'Filesystem Path',
-                    size: 'Size',
-                },
-            },
-            panels: {
-                html: 'HTML',
-                view: 'View',
-                context: 'Context',
-                resources: 'Resources',
-                info: 'Info',
-                notes: 'Notes',
-            },
-        },
+        labels,
     });
     config.skin =
         typeof config.skin === 'string'
@@ -76,7 +77,6 @@ module.exports = function (options) {
                   name: 'default',
                   ...config.skin,
               };
-
     const uiStyles = []
         .concat(config.styles)
         .concat(config.stylesheet)
@@ -87,6 +87,24 @@ module.exports = function (options) {
         .filter((url) => url)
         .map((url) => (url === 'default' ? `/${config.static.mount}/css/highlight.css` : url));
 
+    config.information = (
+        config.information || [
+            {
+                label: labels.builtOn,
+                value: new Date(),
+                type: 'time',
+                format: (value) => {
+                    return value.toLocaleDateString(config.lang);
+                },
+            },
+        ]
+    ).map((item) => ({
+        format: (value) => {
+            return value;
+        },
+        type: 'string',
+        ...item,
+    }));
     config.panels = config.panels || ['html', 'view', 'context', 'resources', 'info', 'notes'];
     config.nav = config.nav || ['search', 'components', 'docs', 'assets', 'information'];
     config.styles = [].concat(uiStyles).concat(highlightStyles);
@@ -95,7 +113,6 @@ module.exports = function (options) {
         .filter((url) => url)
         .map((url) => (url === 'default' ? `/${config.static.mount}/js/mandelbrot.js` : url));
     config.favicon = config.favicon || `/${config.static.mount}/favicon.ico`;
-    config.now = new Date();
 
     const theme = new Theme(Path.join(__dirname, '..', 'views'), config);
 

--- a/packages/mandelbrot/src/theme.js
+++ b/packages/mandelbrot/src/theme.js
@@ -6,53 +6,6 @@ const Theme = require('@frctl/web').Theme;
 const packageJSON = require('../package.json');
 
 module.exports = function (options) {
-    const labels = _.defaultsDeep(_.clone((options || {}).labels || {}), {
-        info: 'Information',
-        builtOn: 'Built on',
-        search: {
-            label: 'Search',
-            placeholder: 'Search…',
-            clear: 'Clear search',
-        },
-        tree: {
-            collapse: 'Collapse tree',
-        },
-        components: {
-            handle: 'Handle',
-            tags: 'Tags',
-            variants: 'Variants',
-            context: {
-                empty: 'No context defined.',
-            },
-            notes: {
-                empty: 'No notes defined.',
-            },
-            preview: {
-                label: 'Preview',
-                withLayout: 'With layout',
-                componentOnly: 'Component only',
-            },
-            path: 'Filesystem Path',
-            references: 'References',
-            referenced: 'Referenced by',
-            resources: {
-                file: 'File',
-                content: 'Content',
-                previewUnavailable: 'Previews are currently not available for this file type.',
-                url: 'URL',
-                path: 'Filesystem Path',
-                size: 'Size',
-            },
-        },
-        panels: {
-            html: 'HTML',
-            view: 'View',
-            context: 'Context',
-            resources: 'Resources',
-            info: 'Info',
-            notes: 'Notes',
-        },
-    });
     const config = _.defaultsDeep(_.clone(options || {}), {
         skin: 'default',
         rtl: false,
@@ -66,7 +19,53 @@ module.exports = function (options) {
         },
         version: packageJSON.version,
         favicon: null,
-        labels,
+        labels: {
+            info: 'Information',
+            builtOn: 'Built on',
+            search: {
+                label: 'Search',
+                placeholder: 'Search…',
+                clear: 'Clear search',
+            },
+            tree: {
+                collapse: 'Collapse tree',
+            },
+            components: {
+                handle: 'Handle',
+                tags: 'Tags',
+                variants: 'Variants',
+                context: {
+                    empty: 'No context defined.',
+                },
+                notes: {
+                    empty: 'No notes defined.',
+                },
+                preview: {
+                    label: 'Preview',
+                    withLayout: 'With layout',
+                    componentOnly: 'Component only',
+                },
+                path: 'Filesystem Path',
+                references: 'References',
+                referenced: 'Referenced by',
+                resources: {
+                    file: 'File',
+                    content: 'Content',
+                    previewUnavailable: 'Previews are currently not available for this file type.',
+                    url: 'URL',
+                    path: 'Filesystem Path',
+                    size: 'Size',
+                },
+            },
+            panels: {
+                html: 'HTML',
+                view: 'View',
+                context: 'Context',
+                resources: 'Resources',
+                info: 'Info',
+                notes: 'Notes',
+            },
+        },
     });
     config.skin =
         typeof config.skin === 'string'
@@ -90,7 +89,7 @@ module.exports = function (options) {
     config.information = (
         config.information || [
             {
-                label: labels.builtOn,
+                label: config.labels.builtOn,
                 value: new Date(),
                 type: 'time',
                 format: (value) => {

--- a/packages/mandelbrot/views/partials/navigation/information.nunj
+++ b/packages/mandelbrot/views/partials/navigation/information.nunj
@@ -5,11 +5,21 @@
                 {{ frctl.theme.get('labels.info') }}
             </div>
         </div>
-        <div class="Tree-aside">
-            {{ frctl.theme.get('labels.builtOn') }}:
-            <time datetime="{{ frctl.theme.get('now').toISOString() }}">
-                {{ frctl.theme.get('now').toLocaleDateString(frctl.theme.get('lang')) }}
-            </time>
-        </div>
+        <dl class="Tree-aside">
+            {% for term in frctl.theme.get('information') %}
+                <div>
+                    <dt class="Tree-asideTerm">{{ term.label }}:</dt>
+                    <dd class="Tree-asideDescription">
+                        {% if term.type == 'time' %}
+                            <time datetime="{{ term.value.toISOString() }}">
+                                {{ term.format(term.value) }}
+                            </time>
+                        {% else %}
+                            {{ term.format(term.value) }}
+                        {% endif %}
+                    </dd>
+                </div>
+            {% endfor %}
+        </dl>
     </div>
 </div>

--- a/packages/mandelbrot/views/partials/navigation/information.nunj
+++ b/packages/mandelbrot/views/partials/navigation/information.nunj
@@ -2,9 +2,9 @@
 <div class="Navigation-group">
     <div class="Tree">
         <div class="Tree-header">
-            <div class="Tree-title">
+            <h3 class="Tree-title">
                 {{ frctl.theme.get('labels.info') }}
-            </div>
+            </h3>
         </div>
         <dl class="Tree-aside">
             {% for term in frctl.theme.get('information') %}

--- a/packages/mandelbrot/views/partials/navigation/information.nunj
+++ b/packages/mandelbrot/views/partials/navigation/information.nunj
@@ -1,3 +1,4 @@
+{% if frctl.theme.get('information').length %}
 <div class="Navigation-group">
     <div class="Tree">
         <div class="Tree-header">
@@ -23,3 +24,4 @@
         </dl>
     </div>
 </div>
+{% endif %}


### PR DESCRIPTION
Resolves #624 and #647.

This will allow users to customize the information properties like this:
```
const mandelbrot = require('@frctl/mandelbrot');

fractal.web.theme(
    mandelbrot({
        information: [
            {
                label: 'version',
                value: '1.2.3',
            },
        ],
    })
);
```
An information property's type can be set to `time` (defaults to `string`), in which case the property is marked up as `<time>` element.
Additionally, we provide an optional format prop if the base value needs to be formatted to a specific output - the usecase here is allowing to customize the date format, but I guess there could be other uses as well, if we should add other property types in the future.

This is the default:
```
fractal.web.theme(
    mandelbrot({
        information: [
            {
                label: 'Built on:',
                value: new Date(),
                type: 'time',
                format: (value) => {
                    return value.toLocaleDateString('en');
                },
            },
        ],
    })
);
```