### PR TITLE
fix: update file extension of docs index in new command

### DIFF
--- a/packages/fractal/src/cli/commands/new.js
+++ b/packages/fractal/src/cli/commands/new.js
@@ -24,7 +24,7 @@ module.exports = {
         const basePath = baseDir.startsWith('/') ? baseDir : Path.join(process.cwd(), baseDir);
         const viewsPath = Path.join(__dirname, '../../../views/cli/new');
         const fractalFileTpl = Path.join(viewsPath, 'fractal.hbs');
-        const docsIndexTpl = Path.join(viewsPath, 'docs/index.hbs');
+        const docsIndexTpl = Path.join(viewsPath, 'docs/index.md');
         const exampleComponent = Path.join(viewsPath, 'components/example');
 
         if (helpers.fileExistsSync(basePath)) {


### PR DESCRIPTION
The default docs index file was renamed in https://github.com/frctl/fractal/commit/b23ecbaa433fb57fae20136ac7ea7e10469a34ff#diff-bce2cc04110d03fb1499379830faa44a173d254ad7f6f3fda808728746b291e5

The new command used the old `.hbs` file extension.

Fix #680 