### PR TITLE
feat: style native select instead of using a plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21818,12 +21818,6 @@
         }
       }
     },
-    "select2": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
-      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw==",
-      "dev": true
-    },
     "semver": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "sass": "^1.30.0",
     "sass-loader": "^10.1.0",
     "sass-mq": "^5.0.1",
-    "select2": "^4.0.13",
     "sinon": "^9.2.2",
     "stylelint": "^13.8.0",
     "stylelint-config-prettier": "^8.0.2",

--- a/packages/mandelbrot/assets/js/components/browser.js
+++ b/packages/mandelbrot/assets/js/components/browser.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import 'select2';
 import storage from '../storage';
 
 export default class Browser {
@@ -16,14 +15,10 @@ export default class Browser {
         this._activeClass = 'is-active';
         this._initTabs();
 
-        $('.FileBrowser-select')
-            .select2({
-                minimumResultsForSearch: Infinity,
-            })
-            .on('change', function () {
-                $(this).closest('.FileBrowser').find('[data-role="resource-preview"]').removeClass(self._activeClass);
-                $(`#${this.value}`).addClass(self._activeClass);
-            });
+        $('.FileBrowser-select').on('change', function () {
+            $(this).closest('.FileBrowser').find('[data-role="resource-preview"]').removeClass(self._activeClass);
+            $(`#${this.value}`).addClass(self._activeClass);
+        });
 
         this._initFileSwitcher();
     }

--- a/packages/mandelbrot/assets/scss/components/_browser.scss
+++ b/packages/mandelbrot/assets/scss/components/_browser.scss
@@ -1,5 +1,3 @@
-@import "select2/dist/css/select2";
-
 .Browser {
     @include trbl(0);
 

--- a/packages/mandelbrot/assets/scss/components/_file-browser.scss
+++ b/packages/mandelbrot/assets/scss/components/_file-browser.scss
@@ -22,18 +22,15 @@
     position: relative;
     appearance: none;
     min-width: 15em;
-    padding: 0 24px 0 8px;
-    border: 1px solid rgba(83, 83, 99, 0.25);
-    border-radius: 4px;
-    font-size: 0.875rem;
-    color: #444;
-    line-height: 28px;
-    height: 28px;
+    padding: 0.3125rem 2rem 0.3125rem 0.5625rem;
+    border: 1px solid $color-frame-border;
+    border-radius: 3px;
+    height: 36px;
     cursor: pointer;
     background-color: #fff;
     background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23888888%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E");
     background-repeat: no-repeat;
-    background-position: right 0.5em top 55%;
+    background-position: right 0.65em top 52%;
     background-size: 0.65em auto;
 
     &::-ms-expand {
@@ -43,11 +40,6 @@
     &::-ms-value {
         color: inherit;
         background: inherit;
-    }
-
-    &:focus {
-        outline: none;
-        border-color: #000;
     }
 }
 

--- a/packages/mandelbrot/assets/scss/components/_file-browser.scss
+++ b/packages/mandelbrot/assets/scss/components/_file-browser.scss
@@ -7,19 +7,6 @@
     margin: -0.75rem -0.75rem 0.75rem -0.75rem;
     padding: 0.5rem 0.75rem;
     background-color: rgba($color-frame-border, 0.05);
-
-    .select2-container {
-        @include font(caption);
-        @include margin-inline(start, -0.25rem);
-
-        margin-bottom: -1px;
-        min-width: 15em;
-    }
-
-    select:focus,
-    select:active {
-        outline: none;
-    }
 }
 
 .FileBrowser-select-label {
@@ -31,36 +18,37 @@
     font-weight: bold;
 }
 
-.select2-selection.select2-selection--single {
-    border-color: $color-frame-border;
-
-    .select2-container--focus & {
-        --border-color: rgb(var(--skin-links));
-
-        outline: none;
-        border-color: $color-link;
-        border-color: var(--border-color, $color-link);
-    }
-}
-
-.select2-results__option {
-    @include font(caption);
-
+.FileBrowser-select {
+    position: relative;
+    appearance: none;
     min-width: 15em;
+    padding: 0 24px 0 8px;
+    border: 1px solid rgba(83, 83, 99, 0.25);
+    border-radius: 4px;
+    font-size: 0.875rem;
+    color: #444;
+    line-height: 28px;
+    height: 28px;
+    cursor: pointer;
+    background-color: #fff;
+    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23888888%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.5em top 55%;
+    background-size: 0.65em auto;
 
-    &[aria-selected="true"] {
-        background-color: rgba($color-frame-border, 0.1) !important;
+    &::-ms-expand {
+        display: none;
     }
-}
 
-.select2-results__option--highlighted[aria-selected] {
-    --background-color: rgb(var(--skin-accent));
-    --color: rgb(var(--skin-complement));
+    &::-ms-value {
+        color: inherit;
+        background: inherit;
+    }
 
-    background-color: $color-header-background !important;
-    background-color: var(--background-color, $color-header-background) !important;
-    color: $color-header-content !important;
-    color: var(--color, $color-header-content) !important;
+    &:focus {
+        outline: none;
+        border-color: #000;
+    }
 }
 
 .FileBrowser-item {

--- a/packages/mandelbrot/package.json
+++ b/packages/mandelbrot/package.json
@@ -50,7 +50,6 @@
     "sass": "^1.30.0",
     "sass-loader": "^10.1.0",
     "sass-mq": "^5.0.1",
-    "select2": "^4.0.13",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0"
   },


### PR DESCRIPTION
Select2 is only used in a single place (assets file browser) in Mandelbrot, but accounts for ~30% of the JS bundle (did not analyze the CSS size, but I would presume the savings are also big). I know Mark had some additional ideas on how to use the Select2 dependency better but those never came to fruition.