### PR TITLE
feat!: switch to fixed versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,5 @@
     }
   },
   "packages": ["packages/*", "examples/*"],
-  "version": "independent"
+  "version": "2.0.6"
 }


### PR DESCRIPTION
Filing this as draft but I would like to make this switch at some point in the near future. We opted for independent versioning at the start so importing existing packages would be easier. In the long term, in my opinion, independent versioning does not work very well with conventional commits. One issue is that when adding new packages at 0.x they never get automatically bumbed to 1.x with conventional commits - they should be bumped manually, but who can determine when te correct time is 🤷 . For example, look at the versions of our core/web packages :)

Additionally, fixed versioning should work better with communicating what versions of different packages work together. Right now, we have some cases in docs where we need to specify "needs fractal X and mandelbrot Y" (for example, the root collections option), because the packages are bumped independently. With fixed versioning, we could always say that "use version X of both or latest".

Notes on merging/releasing this:
- currently I've marked the version in lerna.json to be the version of the package with the current highest version (nunjucks). It should be bumped here if new releases are made before merging this.
- before this is released, the last release commit should be tagged  with a "normal" npm tag in the format of `v1.2.3`. That should inform lerna/conventional commits that that's the correct release to bump from.
- it's probably a good idea to do the release manually, since I've only ever done a switch like this once before and all I can remember from it is that it's a hassle 😬 . Can't be sure that adding the tag I mentioned in the previous point resolves all issues, so better to do it manually.
- oh, and we can probably discuss what the next version should be - we could probably get away with doing a major bump here as well. Did we have some issue with releasing v2 or v3 and should the next major be v4? Additionally, are there any small pieces of legacy code that would be easy to remove? We could also do that before bumping everything to the same version.