### PR TITLE
fix: skip linkRefs if there are no references

### DIFF
--- a/packages/mandelbrot/src/filters.js
+++ b/packages/mandelbrot/src/filters.js
@@ -65,7 +65,7 @@ module.exports = function (theme, env, app) {
     });
 
     env.engine.addFilter('linkRefs', function (str, item) {
-        if (!(item.isComponent || item.isVariant)) {
+        if (!(item.isComponent || item.isVariant) || !item.references.length) {
             return str;
         }
         const refs = item.references;

--- a/packages/mandelbrot/src/filters.js
+++ b/packages/mandelbrot/src/filters.js
@@ -65,7 +65,10 @@ module.exports = function (theme, env, app) {
     });
 
     env.engine.addFilter('linkRefs', function (str, item) {
-        if (!(item.isComponent || item.isVariant) || !item.references.length) {
+        if (!(item.isComponent || item.isVariant)) {
+            return str;
+        }
+        if (!item.references.length) {
             return str;
         }
         const refs = item.references;


### PR DESCRIPTION
If `item.references` is an empty array, an empty regex is created, which matches all empty strings between any two consecutive characters.

So if the input string contains `n` characters, the handle callback is invoked `n + 1` times.
As the parameter is an empty string, an error is thrown and caught each time.
I discovered this in a project where it added several seconds to the page render time.

This PR fixes the issue.