### PR TITLE
perf: avoid extraneous render

### DIFF
--- a/packages/mandelbrot/views/layouts/pen.nunj
+++ b/packages/mandelbrot/views/layouts/pen.nunj
@@ -11,17 +11,6 @@
 
 {% block content %}
 
-{% if frctl.env.server and frctl.env.sync %}
-    {% set rendered = false %}
-{% else %}
-    {% set rendered = entity.render(null, renderEnv, { preview: true, collate: true }) | async(true) %}
-    {% if rendered | isError %}
-        {% set error = rendered %}
-        {% set renderError %}{{ errors.renderError('component', error.message) }}{% endset %}
-        {% set rendered = false %}
-    {% endif %}
-{%- endif %}
-
 <div class="Pen" data-behaviour="pen" id="pen-{{ entity.id }}">
 
     {% block penContent %}

--- a/packages/mandelbrot/views/partials/pen/preview.nunj
+++ b/packages/mandelbrot/views/partials/pen/preview.nunj
@@ -1,9 +1,6 @@
 <div class="Pen-panel Pen-preview Preview" data-behaviour="preview" id="preview-{{ entity.id }}">
     <div class="Preview-wrapper" data-role="resizer">
         <div class="Preview-resizer">
-            {% if renderError -%}
-                {{ renderError }}
-            {% else %}
              <iframe
                 class="Preview-iframe"
                 data-role="window"
@@ -11,7 +8,6 @@
                 {% if entity.display %} style="{% for property, value in entity.display %}{{ property }}: {{ value }} !important; {% endfor %}"{% endif %}
                 marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
             </iframe>
-            {%- endif %}
         </div>
         <div class="Preview-handle" data-role="resize-handle"></div>
         <div class="Preview-overlay"></div>


### PR DESCRIPTION
When investigating performance issues, I discovered that even if I disable any additional panels (like 'html'), a component is still always rendered twice - once in the parent page that contains the iframe tag and then again inside the iframe.

Furthermore, the parent render's result actually seems to be discarded if the render is successful. If it fails, the render error is stored and rendered instead of the iframe. However, the same error would also be rendered inside the iframe if this feature were removed.

I dug around a bit and found that the render result was previously also used as the `srcdoc` attribute on the iframe.
Later, due to SVG rendering issues, [the srcdoc attribute was removed](https://github.com/frctl/mandelbrot/commit/8bdb9e92424ce43d12869ad61d60d33e313ae3ef), but the rendering code was left in place.

So the end result was:

1. If a render fails, the error is caught before rendering an iframe (and the same error inside it).
2. If a render succeeds, its result is discarded and another identical render is done inside the iframe.

Even though 1. seems like a nice optimization, the performance cost of 2. is high enough that it seems wise to remove this feature, which I'm proposing with this PR.

In fact, the whole thing is already being skipped in server+sync mode, so it shouldn't cause any unexpected issues in other modes either.