### PR TITLE
chore(examples): use correct syntax to customize theme

### DIFF
--- a/examples/handlebars/fractal.config.js
+++ b/examples/handlebars/fractal.config.js
@@ -4,6 +4,7 @@
  * Require the path module
  */
 const path = require('path');
+const mandelbrot = require('@frctl/mandelbrot');
 
 /*
  * Require the Fractal module
@@ -38,6 +39,8 @@ fractal.web.set('builder.dest', path.join(__dirname, 'dist'));
 /*
  * Customize Mandelbrot
  */
-fractal.web.set('theme', {
-    panels: ['html', 'view', 'context', 'resources', 'info', 'notes'],
+const customTheme = mandelbrot({
+    // See https://fractal.build/guide/web/default-theme.html#configuration
 });
+
+fractal.web.theme(customTheme);

--- a/examples/twig/fractal.config.js
+++ b/examples/twig/fractal.config.js
@@ -4,6 +4,7 @@
  * Require the path module
  */
 const path = require('path');
+const mandelbrot = require('@frctl/mandelbrot');
 
 /*
  * Require the Fractal module
@@ -42,6 +43,8 @@ fractal.web.set('builder.dest', path.join(__dirname, 'dist'));
 /*
  * Customize Mandelbrot
  */
-fractal.web.set('theme', {
-    panels: ['html', 'view', 'context', 'resources', 'info', 'notes'],
+const customTheme = mandelbrot({
+    // See https://fractal.build/guide/web/default-theme.html#configuration
 });
+
+fractal.web.theme(customTheme);


### PR DESCRIPTION
The current syntax is wrong and doesn’t work. I also removed the panels list since it was the same as the default. Added a link to the available options instead. I know this basically does nothing but it’s useful when you want to quickly tweaks some Mandelbrot settings while working on or reviewing changes.