### PR TITLE
perf: cache highlighted code

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "liftoff": "^3.1.0",
     "lodash": "^4.17.20",
     "log-update": "^4.0.0",
+    "lru-cache": "^6.0.0",
     "marked": "^2.0.0",
     "mime": "^2.5.2",
     "minimist": "^1.2.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "istextorbinary": "^5.12.0",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.20",
+    "lru-cache": "^6.0.0",
     "marked": "^2.0.0",
     "minimist": "^1.2.5",
     "mixwith": "^0.1.1",

--- a/packages/core/src/highlighter.js
+++ b/packages/core/src/highlighter.js
@@ -2,13 +2,44 @@
 
 const HighlightJs = require('highlight.js');
 const _ = require('lodash');
+const LRU = require('lru-cache');
 
+const utils = require('./utils');
+
+const cache = new LRU({
+    // 10MB cache, dunno what's good
+    max: 1024 * 1024 * 10,
+    length: (n) => n.length,
+});
+
+/**
+ * @param {string} content
+ * @param {string} lang
+ */
 module.exports = function highlighter(content, lang) {
-    content = _.toString(content || '');
+    content = _.toString(content);
     lang = lang ? lang.toLowerCase() : lang;
+    const md5 = utils.md5(content);
+    let ret = cache.get(md5);
+
+    if (!ret) {
+        ret = module.exports._highlight(content, lang);
+        cache.set(md5, ret);
+    }
+
+    return ret;
+};
+
+/**
+ * @param {string} content
+ * @param {string} lang
+ */
+module.exports._highlight = function _highlight(content, lang) {
     try {
         return lang ? HighlightJs.highlight(lang, content).value : HighlightJs.highlightAuto(content).value;
     } catch (e) {
         return HighlightJs.highlightAuto(content).value;
     }
 };
+
+module.exports._cache = cache;

--- a/packages/core/test/highlighter.spec.js
+++ b/packages/core/test/highlighter.spec.js
@@ -1,0 +1,73 @@
+const utils = require('../src/utils');
+
+const highlighter = require('../src/highlighter');
+
+const code = `
+module.exports = {
+    foo: 'bar',
+};
+`;
+
+describe('Highlighter', () => {
+    afterEach(() => {
+        highlighter._cache.reset();
+    });
+
+    it('highlights code with lang', () => {
+        const ret = highlighter(code, 'javascript');
+        expect(ret).toEqual(
+            `
+<span class="hljs-built_in">module</span>.exports = {
+    <span class="hljs-attr">foo</span>: <span class="hljs-string">&#x27;bar&#x27;</span>,
+};
+`
+        );
+    });
+
+    it('highlights code without lang', () => {
+        const ret = highlighter(code);
+        expect(ret).toEqual(
+            `
+<span class="hljs-built_in">module</span>.<span class="hljs-built_in">exports</span> = {
+    foo: <span class="hljs-string">&#x27;bar&#x27;</span>,
+};
+`
+        );
+    });
+
+    it('highlights code with invalid lang', () => {
+        console.error = jest.fn();
+        const ret = highlighter(code, 'xsfsd');
+        expect(ret).toEqual(
+            `
+<span class="hljs-built_in">module</span>.<span class="hljs-built_in">exports</span> = {
+    foo: <span class="hljs-string">&#x27;bar&#x27;</span>,
+};
+`
+        );
+        expect(console.error).toHaveBeenCalledWith(
+            "Could not find the language 'xsfsd', did you forget to load/include a language module?"
+        );
+    });
+
+    it('saves highlighted code to cache with md5 key from content', () => {
+        const md5 = utils.md5(code);
+        const hCode = `
+<span class="hljs-built_in">module</span>.exports = {
+    <span class="hljs-attr">foo</span>: <span class="hljs-string">&#x27;bar&#x27;</span>,
+};
+`;
+        const ret = highlighter(code, 'javascript');
+        expect(ret).toEqual(hCode);
+        expect(highlighter._cache.get(md5)).toEqual(ret);
+    });
+
+    it('returns from cache on second run', () => {
+        const spy = jest.spyOn(highlighter, '_highlight');
+        const ret = highlighter(code, 'javascript');
+        const ret2 = highlighter(code, 'javascript');
+
+        expect(ret).toEqual(ret2);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/test/markdown.spec.js
+++ b/packages/core/test/markdown.spec.js
@@ -1,3 +1,5 @@
+const highlighter = require('../src/highlighter');
+
 const md = require('../src/markdown');
 
 const code = `
@@ -31,10 +33,12 @@ describe('Markdown renderer', () => {
     it('renders code correctly', () => {
         const result = md(code);
         expect(result).toMatchSnapshot();
+        highlighter._cache.reset();
     });
 
     it('renders code with lang correctly', () => {
         const result = md(codeWithLang);
         expect(result).toMatchSnapshot();
+        highlighter._cache.reset();
     });
 });


### PR DESCRIPTION
See #605.

I POCed this out to see how much faster page loads / build this will get us, but...
- on a large project, total build time was reduced approx 10s (that would be approximately 2x reduction in time spent highlighting code). not a huge win to be honest, since that project builds for many minutes.
- in server mode, I did not see any very obvious wins. I looked at some pages that had components over 1000 lines long, etc, but not too much changed (looked at TTFB) without the cache vs with.

So I could probably also not merge this, but filing anyway to see what others think. Maybe I'm just bad at testing this stuff :)

P.S. I _think_ the code beautifier in mandelbrot might also take a lot of time but I haven't tested that out. Maybe adding a cache there would also bring some benefits?