### PR TITLE
fix: skip nunjucks path filter, when path is not defined

### DIFF
--- a/packages/nunjucks/src/filters/path.js
+++ b/packages/nunjucks/src/filters/path.js
@@ -5,6 +5,8 @@ const utils = require('@frctl/core').utils;
 
 module.exports = function (fractal) {
     return function (path) {
+        if (!path) return path;
+
         let env = this.lookup('_env');
         let request = env.request || this.lookup('_request') || this.ctx.request;
 


### PR DESCRIPTION
Using nunjucks with the following `context.js`:

```js
module.exports = {
  context: {
    default: {
      source: '/videos/my-video.mp4',
      poster: null,
    },
  },
};
```
and doing this in the `.nunjucks` will throw an error on build, because the `path` parameter is undefined:
```
{% set default = objectAppend(default, 'poster', default.poster | path) %}
```
Is it reasonable to just skip the path filter when the path is not defined? This way we can avoid a lot of additional logic in our templates.