### PR TITLE
feat: update highlight.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14607,9 +14607,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
-      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.1.tgz",
+      "integrity": "sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA=="
     },
     "homedir-polyfill": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "globby": "^11.0.2",
     "gray-matter": "^4.0.2",
     "handlebars": "^4.7.7",
-    "highlight.js": "^10.6.0",
+    "highlight.js": "^10.7.1",
     "inquirer": "^7.3.3",
     "istextorbinary": "^5.12.0",
     "js-beautify": "^1.13.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "co": "^4.6.0",
     "fs-extra": "^9.1.0",
     "globby": "^11.0.2",
-    "highlight.js": "^10.6.0",
+    "highlight.js": "^10.7.1",
     "istextorbinary": "^5.12.0",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.21",

--- a/packages/core/src/highlighter.js
+++ b/packages/core/src/highlighter.js
@@ -7,7 +7,9 @@ module.exports = function highlighter(content, lang) {
     content = _.toString(content || '');
     lang = lang ? lang.toLowerCase() : lang;
     try {
-        return lang ? HighlightJs.highlight(lang, content).value : HighlightJs.highlightAuto(content).value;
+        return lang
+            ? HighlightJs.highlight(content, { language: lang }).value
+            : HighlightJs.highlightAuto(content).value;
     } catch (e) {
         return HighlightJs.highlightAuto(content).value;
     }

--- a/packages/mandelbrot/package.json
+++ b/packages/mandelbrot/package.json
@@ -37,7 +37,7 @@
     "expose-loader": "^2.0.0",
     "file-loader": "^6.2.0",
     "globby": "^11.0.2",
-    "highlight.js": "^10.6.0",
+    "highlight.js": "^10.7.1",
     "jquery": "^3.6.0",
     "jquery-pjax": "^2.0.1",
     "jquery-resizable-dom": "^0.35.0",


### PR DESCRIPTION
This resolves a nuisance that occurs when highlight.js is updated in the background. Highlight.js decided to log a deprecation message for every highlight call. See more in highlightjs/highlight.js#2277