### PR TITLE
chore: drop node 10 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
         token: ${{ secrets.ADMIN_TOKEN }}
     - uses: actions/setup-node@v2.1.5
       with:
-        node-version: 12
+        node-version: 14
         registry-url: 'https://registry.npmjs.org'
     - run: git config user.name github-actions
     - run: git config user.email github-actions@github.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [12, 14, 16]
+        node: [12, 14]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [10, 12, 14]
+        node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/packages/fractal/package.json
+++ b/packages/fractal/package.json
@@ -51,7 +51,7 @@
     "fractal": "./bin/fractal.js"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "scripts": {
     "test:mocha": "mocha --require test/support/env --reporter spec --exclude **/*.spec.js",


### PR DESCRIPTION
Node 10 will be EOL tomorrow! Bumped the release script to use Node 14, since that's the current Active LTS.