### PR TITLE
build: fix mandelbrot build

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "stylelint": "stylelint --ignore-path .gitignore \"**/*.scss\"",
     "validate": "npm run eslint && npm run stylelint",
     "format": "npm run eslint -- --fix",
-    "test": "npm run validate && npm run test:unit",
+    "test": "npm run validate && npm run test:unit && lerna run test",
     "test:unit": "jest",
     "prepare": "husky install"
   },

--- a/packages/mandelbrot/webpack.config.js
+++ b/packages/mandelbrot/webpack.config.js
@@ -95,6 +95,9 @@ module.exports = {
                     },
                     {
                         loader: 'sass-loader',
+                        options: {
+                            sourceMap: true,
+                        },
                     },
                 ],
             },


### PR DESCRIPTION
This fixes Mandelbrot theme build issue and adds the successful build requirement back to the test script.