### PR TITLE
URL encode `:` to `%3A` in pattern urls

### DIFF
--- a/packages/mandelbrot/src/filters.js
+++ b/packages/mandelbrot/src/filters.js
@@ -10,13 +10,13 @@ module.exports = function (theme, env, app) {
             if (!item.path) {
                 return '/';
             }
-            return theme.urlFromRoute('page', { path: item.path });
+            return theme.urlFromRoute('page', { path: item.path }).replace(/:/g, '%3A');
         } else if (item.isComponent || item.isVariant) {
-            return theme.urlFromRoute('component', { handle: item.handle });
+            return theme.urlFromRoute('component', { handle: item.handle }).replace(/:/g, '%3A');
         } else if (item.isAssetSource) {
-            return theme.urlFromRoute('asset-source', { name: item.name });
+            return theme.urlFromRoute('asset-source', { name: item.name }).replace(/:/g, '%3A');
         } else if (item.isAsset) {
-            return Path.join('/', app.get('web.assets.mount'), item.srcPath);
+            return Path.join('/', app.get('web.assets.mount'), item.srcPath).replace(/:/g, '%3A');
         }
         throw new Error(`Cannot generate URL for ${item}`);
     });


### PR DESCRIPTION
Stops `Failed to launch 'foo:btn' because the scheme does not have a registered handler.` type errors on Fractal build generated static navigation.

If your component config file specifies a handle like: `"handle": "foo:btn",` or if you use a pattern with a `:` in the name like "ratio-box--16:9" then all will be fine for local development but after a Fractal build, the statics will not navigate.

My primary use case is name spacing of components. I have one Fractal instance to demonstrate patterns of 2 web sites served from a multisite Craft app. I have website Foo and website Bar, they share a few components but have site specific components also - the kicker being, some of them have the same name. And so I need to be able to use the correct version of a component within other components and on final templates.

Eg: 

```twig
{% include '@foo:btn' with data %} // outputs `btn` from `foo`
{% include '@bar:btn' with data %} // outputs `btn` from `bar`
```