### PR TITLE
fix: return correct relative path if preexisting file ext

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -140,7 +140,7 @@ module.exports = {
         const ext = opts.ext || '';
 
         if (toPath.startsWith('.')) {
-            return ext === '' ? toPath : toPath + ext;
+            return Path.extname(toPath) || ext === '' ? toPath : toPath + ext;
         }
 
         fromPath = getStaticPagePath(fromPath).replace(/\\/g, '/');

--- a/packages/core/test/utils.spec.js
+++ b/packages/core/test/utils.spec.js
@@ -298,6 +298,10 @@ describe('Utils', () => {
         it('returns correct path to file with extension', () => {
             expect(utils.relUrlPath('/path/to/image.png', '/path/b', opts)).toEqual('to/image.png');
         });
+
+        it('returns correct relative path to file with extension', () => {
+            expect(utils.relUrlPath('../to/image.png', '/path/b', opts)).toEqual('../to/image.png');
+        });
     });
 });
 


### PR DESCRIPTION
This PR closes #1064.

It addresses the issue by using regex to find a file extension on the `toPath` when the path is found to start with a `.`.  The solution also incorporates a test to handle this edge case.