### PR TITLE
fix: relative path generated to self

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -151,7 +151,8 @@ module.exports = {
         if (toPath == '/') {
             outputPath = Path.relative(fromPath, toPath).replace(/\\/g, '/');
         } else {
-            outputPath = Path.relative(fromPath, toPath)
+            const relativePath = Path.relative(fromPath, toPath);
+            outputPath = (relativePath ? relativePath : Path.basename(toPath))
                 .replace(/\\/g, '/')
                 .replace(/^\.\.\//, '')
                 .replace('.PLACEHOLDER', ext);

--- a/packages/core/test/utils.spec.js
+++ b/packages/core/test/utils.spec.js
@@ -323,7 +323,7 @@ describe('Utils', () => {
             expect(utils.relUrlPath('https://fractal.build', '/path/b', opts2)).toEqual('https://fractal.build');
         });
 
-        it('returns toPath with extension if it is already a relative path from current directory', () => {
+        it('returns toPath with extension if it is already a path from current directory', () => {
             expect(utils.relUrlPath('./path/to/a', '/path/b', opts2)).toEqual('./path/to/a.html');
         });
 
@@ -337,6 +337,10 @@ describe('Utils', () => {
 
         it('returns correct path to root with extension from current directory', () => {
             expect(utils.relUrlPath('/', '/path/b', opts2)).toEqual('../index.html');
+        });
+
+        it('returns self with extension if it is already a path from self', () => {
+            expect(utils.relUrlPath('/path/to/a', '/path/to/a', opts2)).toEqual('./a.html');
         });
 
         it('returns correct path to file with extension from current directory', () => {


### PR DESCRIPTION
- The path generated to self will be emitted as ./self.ext
- This fixes an issue introduced by #1062