### PR TITLE
fix: don't lowercase name before titlizing to generate label

### DIFF
--- a/packages/core/src/mixins/entity.js
+++ b/packages/core/src/mixins/entity.js
@@ -34,7 +34,7 @@ module.exports = mixin(
                 this._app = parent.source._app;
                 this.name = utils.slugify(name.toLowerCase());
                 this.handle = this._handle(config);
-                this.label = config.label || this._label(config);
+                this.label = config.label || this._label(name);
                 this.title = config.title || this._title(config);
                 this.order = _.isNaN(parseInt(config.order, 10)) ? 10000 : parseInt(config.order, 10);
                 this._isHidden = config.isHidden || config.hidden || false;
@@ -81,8 +81,8 @@ module.exports = mixin(
                 return this.name;
             }
 
-            _label() {
-                return utils.titlize(this.name);
+            _label(name) {
+                return utils.titlize(name);
             }
 
             _title() {

--- a/packages/fractal/src/api/docs/doc.js
+++ b/packages/fractal/src/api/docs/doc.js
@@ -23,8 +23,8 @@ module.exports = class Doc extends Entity {
         return this.name === 'index';
     }
 
-    _label(config) {
-        return config.label || (this.isIndex ? this.source.get('indexLabel') : utils.titlize(config.name));
+    _label(name) {
+        return this.label || (this.isIndex ? this.source.get('indexLabel') : utils.titlize(name));
     }
 
     _handle(config) {


### PR DESCRIPTION
This is a minor change that, when generating labels for components, uses the original case version of `name` instead of the lowercased version. This means having component folder names like `someComponent/` correctly become `Some Component`, whereas without this change, it becomes `Somecomponent`.