### PR TITLE
Fix typo in Nunjucks readme

### DIFF
--- a/packages/nunjucks/README.md
+++ b/packages/nunjucks/README.md
@@ -20,7 +20,7 @@ npm i @frctl/nunjucks --save
 
 ```javascript
 fractal.components.engine("@frctl/nunjucks"); // register the Nunjucks adapter for your components
-fractal.components.set("ext", ".njk"); // look for files with a .nunj file extension
+fractal.components.set("ext", ".njk"); // look for files with a .njk file extension
 ```
 
 ## Customisation


### PR DESCRIPTION
The code references .njk files but the associated code comment references .nunj files. 

Although there is no formal standard for Nunjuck file extensions, the community has largely opted to adopt .njk and it is the recommendation in the Nunjucks spec, so I assume that to be the "correct" option that is meant to be shown here. 