### PR TITLE
fix: wrap long text in navigation tree

### DIFF
--- a/examples/handlebars/components/one-very-very-long-component-name.hbs
+++ b/examples/handlebars/components/one-very-very-long-component-name.hbs
@@ -1,0 +1,1 @@
+A component with a very long name.

--- a/packages/mandelbrot/assets/scss/components/_tree.scss
+++ b/packages/mandelbrot/assets/scss/components/_tree.scss
@@ -1,7 +1,3 @@
-.Tree {
-    white-space: nowrap;
-}
-
 .Tree-header {
     display: flex;
     align-items: center;
@@ -131,6 +127,7 @@
 
         .Tree-entityLink {
             @include padding-inline(start, ($i * 1rem));
+            @include padding-inline(end, ($i * 1rem));
         }
     }
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1892091/140412403-2044ef93-9cc5-4df4-8e8f-89c938aac033.png)


After:
![image](https://user-images.githubusercontent.com/1892091/140412363-72c0944e-66d3-403c-814f-528d79c35849.png)
