### PR TITLE
build: Update marked from 2.0.3 to 4.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16129,9 +16129,9 @@
       "dev": true
     },
     "marked": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
-      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "liftoff": "^3.1.0",
     "lodash": "^4.17.21",
     "log-update": "^4.0.0",
-    "marked": "^2.0.3",
+    "marked": "^4.0.10",
     "mime": "^2.5.2",
     "minimist": "^1.2.5",
     "mixwith": "^0.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "istextorbinary": "^5.15.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "marked": "^2.0.3",
+    "marked": "^4.0.10",
     "minimist": "^1.2.5",
     "mixwith": "^0.1.1",
     "readable-stream": "^3.6.0"

--- a/packages/core/src/markdown.js
+++ b/packages/core/src/markdown.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const marked = require('marked');
+const { marked } = require('marked');
 const _ = require('lodash');
 const highlighter = require('./highlighter');
 const renderer = new marked.Renderer();


### PR DESCRIPTION
Updates marked`-dependency from `2.0.3` to `4.0.10` for some security fixes.

- https://github.com/advisories/GHSA-5v2h-r2cx-5xgj

Also Closes #1126

