### PR TITLE
fix: remove printed out navigation type from header

### DIFF
--- a/packages/mandelbrot/views/partials/header.nunj
+++ b/packages/mandelbrot/views/partials/header.nunj
@@ -8,5 +8,4 @@
         </div>
     </button>
     <a href="{{ path('/') }}" class="Header-title" data-pjax>{{ frctl.get('project.title') | default('Component Library') }}</a>
-    navigation type: {{ frctl.theme.get('navigation') }}
 </div>


### PR DESCRIPTION
Reported here: https://github.com/frctl/fractal-docs/issues/107#issuecomment-1026673252

Mistake on my part to not remove the visible text before merging.