### PR TITLE
Add configuration setting, variantsName

### DIFF
--- a/packages/fractal/src/api/components/component.js
+++ b/packages/fractal/src/api/components/component.js
@@ -24,7 +24,8 @@ module.exports = class Component extends Entity {
         this._notes = config.notes || config.readme || null;
         this._resources = resources;
         this._resourceCollections = null;
-        this._variants = new VariantCollection({ name: `${this.name}-variants` }, [], parent);
+        this._variantsName = config.variantsName || `${this.name}-variants`;
+        this._variants = new VariantCollection({ name: this.variantsName }, [], parent);
         this._referencedBy = null;
         this._references = null;
     }
@@ -66,6 +67,10 @@ module.exports = class Component extends Entity {
 
     get notes() {
         return _.get(this._notes, 'isFile') ? this._notes.getContentSync() : this._notes;
+    }
+
+    get variantsName() {
+        return this._variantsName;
     }
 
     render(context, env, opts) {

--- a/packages/fractal/src/api/variants/collection.js
+++ b/packages/fractal/src/api/variants/collection.js
@@ -177,7 +177,7 @@ module.exports = class VariantCollection extends EntityCollection {
 
         return new VariantCollection(
             {
-                name: `${component.name}-variants`,
+                name: component.variantsName,
             },
             _.orderBy(yield variants, ['order', 'name']),
             component


### PR DESCRIPTION
This PR just adds a configuration setting, `variantsName`, to configure the name of the variants collection for a component. Currently there's two places where the the pattern  of `<component name>-variants` is hard coded, and this string is label converted to Title Case for use in the UI. There's no good way to override this with a theme that I could find either.

This maintains the default functionality, but combines the two places to reference to the `component.variantsName` getting and adds a configuration setting, also `variantsName`, but setting that value, so if you want to have a component where the variants are called "Layouts", "Modifiers", "Version", "Sub Components" etc., you can.